### PR TITLE
feat(renovate): per-chart grouping and auto chart-version bump

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,18 @@
 {
-  "extends": ["config:recommended"],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":configMigration"],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 0,
+  "minimumReleaseAge": "3 days",
+  "timezone": "UTC",
+  "bumpVersions": [
+    {
+      "name": "bump chart version on dependency update",
+      "filePatterns": ["charts/**/Chart.yaml"],
+      "matchStrings": ["^version:\\s(?<version>\\S+)"],
+      "bumpType": "patch"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
@@ -9,14 +20,9 @@
       "groupSlug": "github-actions"
     },
     {
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "chore(deps): minor & patch updates",
-      "groupSlug": "minor-patch"
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "minimumReleaseAge": "3 days"
+      "matchManagers": ["helmv3"],
+      "groupName": "{{packageFileDir}} chart deps",
+      "groupSlug": "{{packageFileDir}}"
     }
-  ],
-  "timezone": "UTC"
+  ]
 }


### PR DESCRIPTION
## Changes
- Group `helmv3` updates **per chart** via `{{packageFileDir}}` template — one PR per chart instead of one shared minor/patch PR across all 9 charts.
- Add `bumpVersions` rule: patch-bump each chart's own top-level `version:` in `charts/**/Chart.yaml` when a dependency updates. `^version:` is line-anchored so it matches the chart version, not the indented dependency `version:` entries.
- Move `minimumReleaseAge: "3 days"` to top level (applies to all update types, was major-only).
- Add `$schema` and `:configMigration`.
- Drop the redundant shared minor/patch + major package rules.

## Motivation
`chart-releaser` (`.github/workflows/release.yml`) only publishes a chart when its `Chart.yaml` top-level `version:` changes. Previously Renovate bumped dependency versions inside `Chart.yaml` but never the chart's own `version:`, so dependency updates merged without ever being released. `bumpVersions` closes that gap. Per-chart grouping keeps each chart releasing on its own cadence (independent charts), unlike the app-repo shared-group pattern used in sibling repos.

## Verification
- `python3 -m json.tool` — JSON valid.
- `bumpVersions` and `packageFileDir` confirmed against official Renovate docs/schema.
- Recommend running `npx renovate-config-validator .github/renovate.json` in CI / locally before relying on it.

## In-depth
- Assumption: top-level `Chart.yaml` `version:` sits at column 0 and dependency `version:` stays indented (holds for all current charts).
- Unknown: `bumpVersions` is a newer Renovate feature — confirm the running Renovate version supports it; if unsupported it no-ops silently (no bump = no release).