### PR TITLE
chore(renovate): enable semantic commit prefixes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
   "prConcurrentLimit": 5,
   "prHourlyLimit": 0,
   "minimumReleaseAge": "3 days",
+  "semanticCommits": "enabled",
   "timezone": "UTC",
   "bumpVersions": [
     {


### PR DESCRIPTION
## Changes
- Add `"semanticCommits": "enabled"` to `.github/renovate.json`.

## Motivation
`semanticCommits` defaults to `"auto"`, which only turns on prefixes when Renovate detects an existing conventional-commit history. This repo's history is free-form, so auto-detection leaves it off — bot PRs come out unprefixed (e.g. "Update mariadb Docker tag to v25"). Forcing `enabled` makes Renovate apply conventional prefixes via the `:semanticPrefixFixDepsChoreOthers` preset already pulled in by `config:recommended` (dependency updates → `fix(deps)`, other changes → `chore(deps)`).

## Verification
- `python3 -m json.tool` — JSON valid.
- Effect visible on the next Renovate-authored PR (titles gain `fix(deps)`/`chore(deps)` prefixes).

## In-depth
- No automation depends on commit type here (releases run via chart-releaser on `Chart.yaml` version changes, not semantic-release). This is for history readability/consistency.