### PR TITLE
feat(renovate): track chart appVersion container images

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,6 +28,11 @@
   ],
   "packageRules": [
     {
+      "description": "Image versions are tracked via Chart.yaml appVersion (custom manager); values.yaml image fields use a registry/name split that helm-values cannot resolve, so disable it to avoid junk deps",
+      "matchManagers": ["helm-values"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["github-actions"],
       "groupName": "github-actions-dependencies",
       "groupSlug": "github-actions"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,18 @@
       "bumpType": "patch"
     }
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track container image version stored in Chart.yaml appVersion",
+      "managerFilePatterns": ["charts/*/Chart.yaml"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?(?: extractVersion=(?<extractVersion>\\S+))?\\s+appVersion:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": ["github-actions"],

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ kube_config
 /charts/*/charts
 .idea
 .DS_Store
+
+.claude/

--- a/charts/bookstack-file-exporter/Chart.yaml
+++ b/charts/bookstack-file-exporter/Chart.yaml
@@ -21,4 +21,5 @@ version: 0.0.2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+# renovate: datasource=docker depName=homeylab/bookstack-file-exporter
 appVersion: "1.4.1"

--- a/charts/bookstack/Chart.yaml
+++ b/charts/bookstack/Chart.yaml
@@ -21,6 +21,7 @@ version: 4.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+# renovate: datasource=docker depName=linuxserver/bookstack versioning=loose extractVersion=^version-(?<version>.+)$
 appVersion: "version-v24.12"
 
 dependencies:

--- a/charts/bookstack/README.md
+++ b/charts/bookstack/README.md
@@ -14,6 +14,8 @@ Table of Contents
 
 This chart deploys [bookstack](https://github.com/BookStackApp/BookStack), an app for self and/or collaborated documentation similar to confluence. This chart includes an option to install mariadb alongside it (default: enabled) and [bookstack-file-exporter](https://github.com/homeylab/helm-charts/tree/main/charts/bookstack-file-exporter) for file backups.
 
+This chart is useful for demoing and light usage. Chart revisions may jump versions, it is recommended to use a dedicated mariadb instance instead and upgrade bookstack incrementally if using this chart for teams or production.
+
 *Note: You should set some chart values by creating your own values.yaml and save that locally*
 
 ## Add Chart Repo

--- a/charts/exportarr/Chart.yaml
+++ b/charts/exportarr/Chart.yaml
@@ -21,6 +21,7 @@ version: 2.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+# renovate: datasource=docker depName=ghcr.io/onedr0p/exportarr
 appVersion: "v2.2.0"
 
 # optional: include qbittorrent-exporter for prometheus

--- a/charts/nut-exporter/Chart.yaml
+++ b/charts/nut-exporter/Chart.yaml
@@ -21,4 +21,5 @@ version: 1.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+# renovate: datasource=docker depName=druggeri/nut_exporter
 appVersion: "3.1.1"

--- a/charts/pihole-exporter/Chart.yaml
+++ b/charts/pihole-exporter/Chart.yaml
@@ -21,4 +21,5 @@ version: 0.0.2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+# renovate: datasource=docker depName=ekofr/pihole-exporter
 appVersion: "v0.4.0"

--- a/charts/qbittorrent-exporter/Chart.yaml
+++ b/charts/qbittorrent-exporter/Chart.yaml
@@ -21,4 +21,5 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+# renovate: datasource=docker depName=caseyscarborough/qbittorrent-exporter
 appVersion: "v1.3.5"

--- a/charts/tdarr-exporter/Chart.yaml
+++ b/charts/tdarr-exporter/Chart.yaml
@@ -21,4 +21,5 @@ version: 1.1.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+# renovate: datasource=docker depName=homeylab/tdarr-exporter
 appVersion: "1.4.3"

--- a/charts/unpoller/Chart.yaml
+++ b/charts/unpoller/Chart.yaml
@@ -23,4 +23,5 @@ version: 2.1.0
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 ## App (unpoller) Version
+# renovate: datasource=docker depName=ghcr.io/unpoller/unpoller
 appVersion: "v2.11.2"

--- a/charts/v-rising/Chart.yaml
+++ b/charts/v-rising/Chart.yaml
@@ -21,4 +21,5 @@ version: 0.0.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+# renovate: datasource=docker depName=trueosiris/vrising versioning=regex:^(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+))?$
 appVersion: "2.1"


### PR DESCRIPTION
## Changes
- Add a `customManagers` (regex) block to `.github/renovate.json` that reads a `# renovate:` comment above each chart's `appVersion:` and treats it as a Docker image version.
- Annotate `appVersion` in all 9 `charts/*/Chart.yaml` with `# renovate: datasource=docker depName=...` (plus per-chart `versioning`/`extractVersion` where the tag scheme is non-standard).
- Disable the built-in `helm-values` manager via a `packageRule` (`enabled: false`).

No `values.yaml` or template changes. The `tag: "" | default .Chart.AppVersion` contract is unchanged.

## Motivation
Container image versions live in `Chart.yaml appVersion` (templates render `{{ .Values.image.tag | default .Chart.AppVersion }}` with empty `tag` in values). No existing Renovate manager read `appVersion`, so image updates were silently missed (e.g. stale tdarr-exporter / bookstack-file-exporter app images). Renovate has no native appVersion manager (renovatebot/renovate#13968); the documented workaround is the `# renovate:` comment + custom regex manager — the approach cert-manager and other appVersion-convention charts use.

`helm-values` is disabled because the repo's `repository`(registry) + `name` split with empty `tag` only yields junk deps (`docker.io`/`ghcr.io` as depNames); the custom manager owns the real image version instead.

## Test plan / verification
Verified with the official `renovate/renovate` docker image (local Node is 20; renovate CLI needs 24+):
- `renovate-config-validator` -> "Config validated successfully".
- Local extract dry-run: the `regex` (custom) manager extracts **9/9** appVersion deps with correct depNames + currentValues (incl. `linuxserver/bookstack @ version-v24.12` via extractVersion, `trueosiris/vrising` via regex versioning).
- `helmv3` continues extracting OCI subchart deps (mariadb, bookstack-file-exporter, qbittorrent-exporter, tdarr-exporter).
- `helm lint` passes on all 9 charts.

## In-depth
- **bumpVersions interaction (unverified locally):** extract-mode dry-run does not create branches, so whether the existing `bumpVersions` patch-bumps each chart's `version:` when its `appVersion` updates can only be confirmed on the first real Mend PR. If it misfires, fallback is to move `bumpVersions` into a `packageRule` scoped with `matchFileNames: ["charts/**"]`.
- **bookstack / v-rising tag schemes** are the noise-prone ones; their `versioning`/`extractVersion` should be sanity-checked against the first proposed update.
- **Follow-ups (out of scope):** (1) re-vendoring stale embedded `.tgz` (e.g. `charts/exportarr/charts/tdarr-exporter-1.0.0.tgz` vs declared `1.1.7`) needs `helm dependency update` in CI; (2) optional convention cleanup to collapse the `repository`(registry)+`name` split into a single full `repository` path — a separate breaking (major-version) change with no Renovate benefit, deliberately not bundled here.