### PR TITLE
feat(nut-exporter): deprecate in favor of upstream first-party chart

### DIFF
--- a/charts/nut-exporter/Chart.yaml
+++ b/charts/nut-exporter/Chart.yaml
@@ -1,6 +1,14 @@
 apiVersion: v2
 name: nut-exporter
-description: A Helm chart for Kubernetes
+description: |
+  DEPRECATED - superseded by the first-party upstream chart maintained by the
+  nut_exporter author. See https://github.com/DRuggeri/nut_exporter (charts/nut-exporter).
+  This chart is no longer maintained and will receive no further updates.
+
+# This chart is deprecated. The nut_exporter author now publishes an official
+# chart that is a superset of this one (adds ingress + Grafana dashboard configmap,
+# tracks newer appVersions). No further releases will be cut here.
+deprecated: true
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,11 +23,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-# renovate: datasource=docker depName=druggeri/nut_exporter
+# Renovate annotation intentionally removed: this chart is deprecated and pinned.
+# Do not re-add it, or Renovate will resume opening appVersion/version bump PRs.
 appVersion: "3.1.1"

--- a/charts/nut-exporter/README.md
+++ b/charts/nut-exporter/README.md
@@ -1,4 +1,34 @@
 # nut-exporter
+
+> [!WARNING]
+> **DEPRECATED.** This chart is superseded by the first-party chart maintained by the
+> `nut_exporter` author and will receive no further updates. Please migrate to the
+> upstream chart: **https://github.com/DRuggeri/nut_exporter** (`charts/nut-exporter`).
+>
+> The upstream chart is a superset of this one — it tracks newer `appVersion`s and adds
+> Ingress and a Grafana dashboard ConfigMap. Existing installs keep working, but no new
+> versions will be released here.
+
+## Migration to the upstream chart
+
+Switching repos requires rewriting your values file — the value keys differ. Mapping:
+
+| This chart (homeylab) | Upstream (DRuggeri) | Notes |
+| --------------------- | ------------------- | ----- |
+| `image.repository: docker.io` + `image.name: druggeri/nut_exporter` | `image.repository: ghcr.io/druggeri/nut_exporter` | Same binary, different registry. |
+| `settings.config.*` | `settings.config.*` | Carried over; confirm key names against upstream `values.yaml`. |
+| `settings.auth.nut_exporter_username` / `_password` | `settings.auth.*` / `existingSecret` | Confirm against upstream `values.yaml`. |
+| `existingSecret` | `existingSecret` | Same intent. |
+| `webconfig_file` | `webconfig_file` | Same intent. |
+| `metrics.serviceMonitor.*` | `metrics.serviceMonitor.*` | Same intent. |
+| (not available) | `ingress.*` | New upstream feature. |
+| (not available) | dashboard ConfigMap | New upstream feature. |
+
+> [!NOTE]
+> This chart's post-install `helm test` connection check has no upstream equivalent.
+> Always diff your values against the upstream `values.yaml` before migrating — verify
+> every key rather than assuming a 1:1 match.
+
 Table of Contents
 - [nut-exporter](#nut-exporter)
   - [Add Chart Repo](#add-chart-repo)


### PR DESCRIPTION
## Changes
- `Chart.yaml`: set `deprecated: true`; bump chart `version` 1.0.0 → 1.1.0 (chart-releaser needs a new version to cut the deprecated release); rewrite `description` to point at upstream.
- Remove the Renovate `appVersion` annotation from `Chart.yaml` so the custom-manager + bumpVersions rules in `.github/renovate.json` no longer open bump PRs for this dead chart. Replaced with a comment explaining why it must not be re-added.
- `README.md`: deprecation warning banner + a migration section with a values-key remap table to the upstream chart.

## Motivation
The `nut_exporter` author now publishes an official first-party Helm chart: https://github.com/DRuggeri/nut_exporter (`charts/nut-exporter`), release `helm-nut-exporter-1.0.1` (appVersion 3.2.6). Template diff shows it is a superset of this chart — covers every monitoring feature here (Deployment, Service, ServiceMonitor, PrometheusRule, webconfig TLS) and adds Ingress + a Grafana dashboard ConfigMap, while tracking newer appVersions. Maintaining a parallel chart is duplicate work with drift risk.

## Assumptions / unknowns
- No feature regression strands users; the only thing without an upstream equivalent is this chart's post-install `helm test` connection check (cosmetic).
- The real migration cost is values-schema differences (image registry `docker.io` → `ghcr.io`, creds env keys), documented in the README table. Users should diff against upstream `values.yaml` rather than assume a 1:1 mapping.

## Test plan
- `helm lint charts/nut-exporter` → passes (only the pre-existing `icon is recommended` info).
- After merge to `main`: `chart-releaser-action` cuts `nut-exporter-1.1.0` flagged deprecated and updates `index.yaml`; `helm` will print a DEPRECATED warning on install/search.
- Existing installs continue to function; no new releases will be cut here.

## In-depth
- Chose to deprecate (keep) rather than delete — existing installs and `index.yaml` history stay resolvable.
- Renovate stop handled locally in the chart (annotation removal) rather than via a `renovate.json` packageRule, to keep the deprecation self-contained in one chart directory.