### PR TITLE
feat(pihole-exporter): support v1.x (Pi-hole v6 API), supersedes #107

### DIFF
--- a/charts/pihole-exporter/Chart.yaml
+++ b/charts/pihole-exporter/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 # renovate: datasource=docker depName=ekofr/pihole-exporter
-appVersion: "v0.4.0"
+appVersion: "v1.2.0"

--- a/charts/pihole-exporter/README.md
+++ b/charts/pihole-exporter/README.md
@@ -1,6 +1,6 @@
 # pihole-exporter
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.0](https://img.shields.io/badge/AppVersion-v0.4.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.0](https://img.shields.io/badge/AppVersion-v1.2.0-informational?style=flat-square)
 
 Table of Contents
 - [pihole-exporter](#pihole-exporter)
@@ -12,6 +12,13 @@ Table of Contents
   - [References](#references)
 
 A Helm Chart to deploy a Prometheus [exporter](https://github.com/eko/pihole-exporter) for Pi-hole. Based on `ekofr/pihole-exporter` image.
+
+> [!IMPORTANT]
+> **Chart `0.1.0` upgrades the exporter to v1.x (Pi-hole v6 API).** This is a breaking change:
+> - Requires a **Pi-hole v6+** server.
+> - The exporter now reads only `PIHOLE_PASSWORD`; the separate `PIHOLE_API_TOKEN` env var was removed upstream. The chart maps both `settings.auth.password` and the deprecated `settings.auth.token` to `PIHOLE_PASSWORD` (it accepts a Pi-hole app password or the legacy WEBPASSWORD API token).
+> - If you use `settings.auth.existingSecret`, the secret must provide the `PIHOLE_PASSWORD` key.
+> - Still on Pi-hole v5? Pin the chart to `0.0.2` (`--version 0.0.2`).
 
 ## Add Chart Repo
 ```bash
@@ -91,9 +98,9 @@ For a full list of values, see [values.yaml](values.yaml). Some of the most impo
 | settings.config.hostname | string | `"pi-hole.localdomain"` | Set the pihole host or IP address |
 | settings.config.port | string | `nil` | Set the pihole port on the pihole host to use, default `80` set by container image |
 | settings.config.protocol | string | `""` | Set the pihole host protocol: `http` or `https`, default `http` set by container image |
-| settings.auth.existingSecret | string | `""` | use existing secret instead of `auth.password` or `auth.token`. Use variables `PIHOLE_PASSWORD` or `PIHOLE_API_TOKEN` |
-| settings.auth.password | string | `""` | Set the pihole password for auth |
-| settings.auth.token | string | `""` | Set the pihole token for auth, if token is specified, password will be ignored |
+| settings.auth.existingSecret | string | `""` | use existing secret instead of `auth.password`/`auth.token`. The secret must provide the `PIHOLE_PASSWORD` key (`PIHOLE_API_TOKEN` is no longer read by v1.x) |
+| settings.auth.password | string | `""` | Set the pihole app password (or legacy WEBPASSWORD API token). Maps to `PIHOLE_PASSWORD` |
+| settings.auth.token | string | `""` | DEPRECATED alias for `auth.password`; if set, takes precedence. Also maps to `PIHOLE_PASSWORD` |
 | service.name | string | `"metrics"` | set name for the service |
 | service.port | int | `9617` | set port for pihole-exporter scraping, should match the pihole-exporter container port in `settings.config.containerPort` |
 | service.protocol | string | `"TCP"` | set protocol for the service |

--- a/charts/pihole-exporter/templates/deployment.yaml
+++ b/charts/pihole-exporter/templates/deployment.yaml
@@ -65,12 +65,12 @@ spec:
               value: {{ $val | quote }}
           {{- end }}
         {{- if not .Values.settings.auth.existingSecret }}
-          {{- if .Values.settings.auth.token }}
-            - name: PIHOLE_API_TOKEN
-              value: {{ .Values.settings.auth.token | quote }}
-          {{- else if .Values.settings.auth.password }}
+          {{- /* v1.x exposes only PIHOLE_PASSWORD; it accepts either a password
+                 or the legacy WEBPASSWORD API token. `token` is kept as a
+                 deprecated alias and routed to PIHOLE_PASSWORD. */}}
+          {{- with (.Values.settings.auth.token | default .Values.settings.auth.password) }}
             - name: PIHOLE_PASSWORD
-              value: {{ .Values.settings.auth.password | quote }}
+              value: {{ . | quote }}
           {{- end }}
         {{- end }}
           envFrom:

--- a/charts/pihole-exporter/values.yaml
+++ b/charts/pihole-exporter/values.yaml
@@ -39,13 +39,15 @@ settings:
     port: 
     # -- Set the port for metrics scraping
     containerPort: 9617
-  # -- Set auth configuration for pihole
+  # -- Set auth configuration for pihole.
+  # As of pihole-exporter v1.x (Pi-hole v6 API) the exporter reads only `PIHOLE_PASSWORD`.
+  # It accepts either the Pi-hole app password or the legacy WEBPASSWORD API token.
   auth:
-    # -- Set the pihole password for auth
+    # -- Set the pihole app password (or legacy WEBPASSWORD API token) for auth. Maps to `PIHOLE_PASSWORD`.
     password: ""
-    # -- Set the pihole token for auth, if token is specified, password will be ignored
+    # -- DEPRECATED alias for `auth.password`, kept for backwards compatibility. If set, takes precedence over `auth.password`. Also maps to `PIHOLE_PASSWORD` (the separate `PIHOLE_API_TOKEN` env var was removed in upstream v1.x).
     token: ""
-    # -- use existing secret instead of `auth.password` or `auth.token`. Use variables `PIHOLE_PASSWORD` or `PIHOLE_API_TOKEN`
+    # -- use existing secret instead of `auth.password`/`auth.token`. The secret must provide the `PIHOLE_PASSWORD` key (`PIHOLE_API_TOKEN` is no longer read by v1.x).
     existingSecret: ""
 
 # -- Add extra environment variables


### PR DESCRIPTION
## Changes
- `templates/deployment.yaml`: route both `settings.auth.token` and `settings.auth.password` to a single `PIHOLE_PASSWORD` env var (token takes precedence). Removes the now-dead `PIHOLE_API_TOKEN` branch.
- `Chart.yaml`: `appVersion` `v0.4.0` → `v1.2.0`; chart `version` `0.0.2` → `0.1.0`.
- `values.yaml` + chart `README.md`: document PIHOLE_PASSWORD-only auth, mark `auth.token` deprecated, add Pi-hole v6 breaking-change callout, update badges.

## Motivation
Renovate #107 bumps `ekofr/pihole-exporter` `v0.4.0` → `v1.x`, a breaking major. Upstream v1.x migrated to the Pi-hole v6 API and **removed `PIHOLE_API_TOKEN`** (v1.0.1: "Replaced missing API_TOKEN with PASSWORD"). It now reads only `PIHOLE_PASSWORD`, which accepts either a Pi-hole app password or the legacy WEBPASSWORD API token. The chart previously emitted `PIHOLE_API_TOKEN` when `auth.token` was set, so token-auth users would break silently after the bump. This PR carries the appVersion bump plus the required auth migration, so it supersedes #107.

## Assumptions
- Requires a Pi-hole v6+ server. Users still on v5 should pin `--version 0.0.2` (noted in README callout).
- `auth.token` retained as a deprecated back-compat alias rather than removed, to avoid breaking existing values files.

## Test plan
No chart test harness exists; verified via render assertions + lint (helm v4.0.5):
- `auth.token` only → `PIHOLE_PASSWORD` (no `PIHOLE_API_TOKEN`)
- `auth.password` only → `PIHOLE_PASSWORD`
- both set → token wins
- `existingSecret` → only `secretRef`, no inline env
- defaults → neither env emitted
- default image tag → `ekofr/pihole-exporter:v1.2.0`
- `helm lint` → 0 failed; full render contains 0 `PIHOLE_API_TOKEN`

## In-depth
Chose a minor bump (`0.1.0`) over patch to signal the breaking config change on a 0.x chart and to exceed the `0.0.3` Renovate would auto-apply. Did the work on a fresh branch rather than Renovate's branch to avoid rebase/overwrite; #107 will be closed in favor of this.