### PR TITLE
fix(renovate): anchor bumpVersions regex so chart version actually bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
     {
       "name": "bump chart version on dependency update",
       "filePatterns": ["charts/**/Chart.yaml"],
-      "matchStrings": ["^version:\\s(?<version>\\S+)"],
+      "matchStrings": ["\\nversion:\\s(?<version>\\S+)"],
       "bumpType": "patch"
     }
   ],


### PR DESCRIPTION
## Changes
`bumpVersions[0].matchStrings` changed from `^version:\s(?<version>\S+)` to `\nversion:\s(?<version>\S+)`.

## Motivation
The chart `version` was never getting bumped on Renovate appVersion-update PRs (e.g. #112, #109, #106 — all changed `appVersion` but left `version` untouched).

Root cause: Renovate runs the `bumpVersions` matchString with `.exec()` against the **whole `Chart.yaml` as one string**, and compiles it with **no flags** (no `m`). With no `m` flag, `^` anchors to start-of-file — which is `apiVersion: v2`, not the mid-file `version:` line — so the pattern never matched and `bumpVersions` silently no-opped.

Because chart-releaser keys releases on `Chart.yaml: version` (with `CR_SKIP_EXISTING: true`), a PR that bumps only `appVersion` merges to an already-released `version` and publishes **nothing** — the new image ships in no installable chart.

Verified against renovate source:
- `lib/workers/repository/update/branch/bump-versions.ts`: `matchStringRegex.exec(fileContents)` — whole file, single exec.
- `lib/util/regex.ts`: `regEx()` applies no default flags.

## Fix
Use a literal newline anchor (`\nversion:`) instead of `^`. This line-anchors without depending on the multiline flag or inline `(?m)` (which native JS RegExp doesn't reliably parse), so it's engine-agnostic.

## Test plan
Regex run against every `charts/*/Chart.yaml`:

| chart | captured version |
|---|---|
| bookstack | 4.1.0 |
| bookstack-file-exporter | 0.0.2 |
| exportarr | 2.0.0 |
| nut-exporter | 1.1.0 |
| pihole-exporter | 0.1.0 |
| qbittorrent-exporter | 0.1.0 |
| tdarr-exporter | 1.1.7 |
| unpoller | 2.1.0 |
| v-rising | 0.0.1 |

All 9 match the chart `version` (not `appVersion`). Old pattern returned NO MATCH on all.

## In-depth
- Alternative `(?m)^version:` (inline multiline) was rejected: re2 (renovate's engine) supports it, but I could not verify the inline form in renovate's actual engine, and native JS RegExp parses `/m` flag ≠ inline `(?m)`. The `\n` anchor needs no flags and was verifiable directly.
- **Existing open Renovate PRs (#112 etc.) were created before this fix** and still carry an unbumped `version`. After this merges they need a Renovate rebase (or a manual `version` bump) to pick up the chart-version bump.
- bumpType remains `patch`; breaking app upgrades (e.g. tdarr v2) may warrant a manual minor bump as a judgment call.