### PR TITLE
fix(renovate): scope bumpVersions to the updated chart's dir

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,14 +6,6 @@
   "minimumReleaseAge": "3 days",
   "semanticCommits": "enabled",
   "timezone": "UTC",
-  "bumpVersions": [
-    {
-      "name": "bump chart version on dependency update",
-      "filePatterns": ["charts/**/Chart.yaml"],
-      "matchStrings": ["\\nversion:\\s(?<version>\\S+)"],
-      "bumpType": "patch"
-    }
-  ],
   "customManagers": [
     {
       "customType": "regex",
@@ -41,6 +33,18 @@
       "matchManagers": ["helmv3"],
       "groupName": "{{packageFileDir}} chart deps",
       "groupSlug": "{{packageFileDir}}"
+    },
+    {
+      "description": "Bump the chart's own version when its appVersion image is updated. Scoped via {{packageFileDir}} to the updated chart's dir so unrelated charts are not bumped. Patch upstream -> chart patch, minor/major upstream -> chart minor.",
+      "matchFileNames": ["charts/**"],
+      "bumpVersions": [
+        {
+          "name": "bump chart version on dependency update",
+          "filePatterns": ["{{packageFileDir}}/Chart.{yaml,yml}"],
+          "matchStrings": ["\\nversion:\\s(?<version>\\S+)"],
+          "bumpType": "{{#if isPatch}}patch{{else}}minor{{/if}}"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Changes
- Moved `bumpVersions` from top-level into a `packageRules` entry with `matchFileNames: ["charts/**"]`.
- Scoped `filePatterns` to `{{packageFileDir}}/Chart.{yaml,yml}` (was `charts/**/Chart.yaml`).
- Switched `bumpType` from `patch` to conditional `{{#if isPatch}}patch{{else}}minor{{/if}}`.

## Motivation
#113 fixed the matchStrings anchor so `bumpVersions` finally fires. That exposed a second bug: the top-level rule's `charts/**/Chart.yaml` filePattern bumps **every** chart's `version` on **any** single-chart update PR.

Observed on #112 after its rebase — a tdarr-only image update rewrote all 9 `Chart.yaml` files (bookstack, exportarr, nut-exporter, etc. all version-bumped). chart-releaser keys releases on `version`, so merging would cut spurious releases for 8 unchanged charts.

Renovate's documented pattern scopes the bump to the updated dependency's directory via `{{packageFileDir}}`, so only the chart that actually changed gets bumped.

## In-depth
- Conditional `bumpType`: patch upstream image bump -> chart patch; minor/major upstream -> chart minor. Means breaking app upgrades (e.g. tdarr `1.4.3`->`2.1.0`) auto-bump the chart minor (`1.1.7`->`1.2.0`) and signal "review before upgrading" without a manual edit. Taken from Renovate's own bumpVersions example.
- matchStrings keeps the `\nversion:` newline anchor from #113 (engine-agnostic line anchor; avoids matching `appVersion`).

## Test plan / verification
- `renovate-config-validator`: **Config validated successfully**.
- Scoping behavior relies on Renovate's documented `{{packageFileDir}}` semantics; the local-platform dry-run cannot exercise the branch worker (it skips with "Branch is not pending"), so runtime scoping is not directly reproduced here.

## Follow-up
- After merge, **#112 needs another Renovate rebase** to drop the 8 spurious chart bumps and keep only `tdarr-exporter` (which should land as a **minor** `1.1.7`->`1.2.0` under the new conditional rule). Other pre-existing appVersion PRs (#106) likewise.