### PR TITLE
docs(tdarr-exporter): add v2 upgrade matrix row

### DIFF
--- a/charts/tdarr-exporter/README.md
+++ b/charts/tdarr-exporter/README.md
@@ -96,6 +96,10 @@ helm upgrade -f my-values.yaml tdarr-exporter -n tdarr-exporter oci://registry-1
 ### Upgrade Matrix For Releases
 _The matrix below displays certain versions of this helm chart that could result in breaking changes._
 
+| Start Chart Version | Target Chart Version | Upgrade Steps |
+| ------------------- | -------------------- | ------------- |
+| `1.1.X` | `1.2.0` | Exporter upgraded to upstream `v2.x` (`appVersion` `1.4.3` -> `2.1.0`).<br><br>**No chart configuration changes** - `values.yaml` is unchanged, no action needed on your values file.<br><br>This is a breaking _upstream_ release: it requires Tdarr `v2.24.01`+ and renames/removes many Prometheus metrics and labels, so existing dashboards and alerts will break. Review the [upstream v2.0.0 release notes](https://github.com/homeylab/tdarr-exporter/releases/tag/v2.0.0) and reimport the [Grafana dashboard](https://grafana.com/grafana/dashboards/20388-tdarr/) before upgrading. |
+
 ## Configuration Options
 For a full list of options, see `values.yaml` file.
 


### PR DESCRIPTION
## Changes
Populate the previously-empty `Upgrade Matrix For Releases` table in `charts/tdarr-exporter/README.md` with the `1.1.X` -> `1.2.0` row, matching the format used by the bookstack / exportarr / unpoller / qbittorrent-exporter charts.

## Motivation
Chart `1.2.0` (PR #112) bumps the exporter to upstream `v2.x`. Chart consumers install via helm and may never read upstream release notes, so the breaking-upgrade gate belongs in the chart README at the point of consumption.

The row is deliberately thin and points to upstream rather than mirroring its migration tables:
- States explicitly there is **no chart config change** (`values.yaml` unchanged) - the breakage is entirely upstream-app-side.
- Gates on the runtime requirement (Tdarr `v2.24.01`+).
- Headlines the risk (metric/label renames break dashboards/alerts) and links the upstream v2.0.0 notes + Grafana dashboard.

This is lighter than the pihole-exporter callout because, unlike pihole (where the chart's own `auth`/`existingSecret` surface changed), tdarr-exporter's chart interface is unchanged.

## Test plan
Docs-only; rendered the table to confirm format matches sibling charts. No template/values changes.

## Note
Separate from PR #112 on purpose - #112 is a Renovate-owned branch and a manual commit there would be lost on its next rebase.