### PR TITLE
fix(bookstack): use regex versioning so renovate can track version- tags

### DIFF
--- a/charts/bookstack/Chart.yaml
+++ b/charts/bookstack/Chart.yaml
@@ -21,7 +21,7 @@ version: 4.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-# renovate: datasource=docker depName=linuxserver/bookstack versioning=loose extractVersion=^version-(?<version>.+)$
+# renovate: datasource=docker depName=linuxserver/bookstack versioning=regex:^version-v(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+))?$
 appVersion: "version-v24.12"
 
 dependencies:


### PR DESCRIPTION
## Changes
Replaced the bookstack image's Renovate annotation versioning in `charts/bookstack/Chart.yaml`:
- before: `versioning=loose extractVersion=^version-(?<version>.+)$`
- after: `versioning=regex:^version-v(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+))?$`

Comment-only change. No chart `version` bump, no `appVersion` change, no template/values change.

## Motivation
Renovate was silently **skipping** the bookstack image — it produced zero update PRs and showed no dependency in the Dependency Dashboard (#98). A `renovate/renovate` docker dry-run gave the root cause:

```
DEBUG: Dependency linuxserver/bookstack has unsupported/unversioned value version-v24.12 (versioning=loose)
DEBUG: Skipping linuxserver/bookstack because no currentDigest or pinDigests
```

The raw tag `version-v24.12` is unparseable under `loose`, so Renovate treated it as a digest pin, found no digest, and skipped the dependency. `extractVersion` did not help: it filters the versions returned by the datasource, it does **not** make the current value parseable. A `regex` versioning that parses the raw `version-vX.Y(.Z)?` tag directly fixes this (same technique already used for v-rising).

## Test plan
`renovate/renovate` docker dry-run (`renovate --platform=local --dry-run=full`), before vs after:
- before: 8 flattened updates; `linuxserver/bookstack` skipped (unversioned).
- after: 10 flattened updates; `linuxserver/bookstack` detected, resolves `version-v26.03.5` (with `version-v26.05` pending under `minimumReleaseAge`). No skip.
- `helm lint charts/bookstack` → `0 chart(s) failed`.

## In-depth
- Verified against linuxserver/bookstack's real tag scheme (`version-v26.05`, `version-v26.03.5`, ...); the `^version-v` anchor excludes arch-prefixed tags (`amd64-version-...`).
- This keeps the existing appVersion + customManager design (which matches the kube-state-metrics convention) rather than migrating to a populated-`tag` layout, which would make `appVersion` go stale for no convention gain.
- Out of scope / confirmed non-issues during investigation: nut-exporter is untracked **by design** (`deprecated: true`, annotation intentionally removed); embedded sub-chart `.tgz`/`Chart.lock` are gitignored and build fine on a clean checkout (dependency-pin lag is just `minimumReleaseAge`).