### PR TITLE
feat!: upgrade unpoller to v3.2.0, bump chart to 3.0.0

### DIFF
--- a/charts/unpoller/Chart.yaml
+++ b/charts/unpoller/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 ## Chart Version
-version: 2.1.0
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,4 +24,4 @@ version: 2.1.0
 # It is recommended to use it with quotes.
 ## App (unpoller) Version
 # renovate: datasource=docker depName=ghcr.io/unpoller/unpoller
-appVersion: "v2.11.2"
+appVersion: "v3.2.0"

--- a/charts/unpoller/README.md
+++ b/charts/unpoller/README.md
@@ -47,6 +47,8 @@ Click below to expand for an example of a valid `custom-values.yaml` file.
 
 ```yaml
 # custom-values.yaml
+# UniFi Network Application (self-hosted Linux/Docker): use port 8443
+# UniFi OS devices (UDM/UCG/UXG): use port 443, no path — e.g. "https://192.168.1.1"
 settings:
   unifi:
     config:
@@ -104,12 +106,13 @@ _The matrix below displays certain versions of this helm chart that could result
 | Start Chart Version | Target Chart Version | Upgrade Steps |
 | ------------------- | -------------------- | ------------- |
 | `1.X.X` | `2.0.0` | Configuration is no longer specified in `config` section as a single key/value object. There is now dedicated sections in the `config` section for each part of unpoller. This allows for easier usability. |
+| `2.X.X` | `3.0.0` | Upgrades unpoller `v2.11.2` -> `v3.2.0`. This is a breaking upstream release — review the [v3.0.0 release notes](https://github.com/unpoller/unpoller/releases/tag/v3.0.0) and [v3.2.0 release notes](https://github.com/unpoller/unpoller/releases/tag/v3.2.0) before upgrading.<br><br>**New chart value `settings.prometheus.interval`** (default `60s`): unpoller v3.2.0 introduced background metric caching. Align your Prometheus `scrapeInterval` with this value. |
 
 
 ## Prerequisites
 Ensure you have created a user in your unifi site as described here: https://unpoller.com/docs/install/controllerlogin
 
-For a Non UnifiOS Controller (like: [unifi-controller](https://hub.docker.com/r/linuxserver/unifi-controller)), email used for login will be the `user` used for authentication.
+For the self-hosted UniFi Network Application, email used for login will be the `user` used for authentication.
 
 ## Configuration Options
 ### Descriptions
@@ -122,13 +125,15 @@ Comments in the provided `values.yaml` provide helpful descriptions. Some of the
 | `metrics` | `*` | This section allows users to set configuration for Prometheus `podAnnotations`, `serviceMonitors`, etc. See `values.yaml` section for more details on what can be customized. |
 | `existingSecret` |  | Replaces auth sections of `settings.*.auth` with user supplied secret. Secrets should have key/value for env vars. |
 | `setttings.unifi.config` | `*` | Unifi connection configuration section.<br><br>If scraping multiple controllers, this section uses the `_0_` number, [reference]( https://unpoller.com/docs/install/configuration) - multiple controllers section. Use `extraEnv` section to specify more controllers. |
-|  |  `url` | `https://unifi-controller.localdomain:8443` |
+|  |  `url` | `https://unifi-network-application.localdomain:8443` for self-hosted; UniFi OS devices (UDM/UCG/UXG) use port `443` with no path suffix |
+| `setttings.unifi.config` | `api_key` | Optional. Enables additional metrics in unpoller v3+. Set via `existingSecret` (preferred) or `extraEnv` using key `UP_UNIFI_CONTROLLER_0_API_KEY`. |
 | `settings.unifi.auth` | `*` | This section will be ignored if `existingSecret` is supplied. Provide username/password here. |
-|  | `user` | For a Non UnifiOS Controller (like: [unifi-controller](https://hub.docker.com/r/linuxserver/unifi-controller)), email used for login, will be the `user` |
+|  | `user` | For the self-hosted UniFi Network Application, email used for login will be the `user` |
 |  | `pass` | Provide the password for the metrics user. |
 | `setttings.influxdb.config` | `*` | Send to influxdb, use `setttings.influxdb.enabled` to use this feature. Not enabled by default. |
 | `setttings.prometheus` | `*` | Prometheus settings, uncomment `disable` and set to `true` if you want Prometheus disabled. |
 | `setttings.prometheus` | `namespace` | By default unpoller is going to use the value of `UP_PROMETHEUS_NAMESPACE` value (this setting) and not your actual deployed namespace to prefix the metrics with a string. Since the grafana [charts](https://github.com/unpoller/dashboards) all have `unpoller_` prefix set in the prom queries, you should put this as `unpoller`. _Note: You can install this helm chart in any namespace you'd like, just set this variable to `unpoller` to work with the existing dashboards without changes._ |
+| `setttings.prometheus` | `interval` | Background poll interval for UniFi data collection (unpoller v3.2.0+). Default `60s`. Minimum effective value is `15s`. The background cache cannot be disabled. Align your Prometheus scrape interval with this value. |
 | `settings.unpoller` | `*` | Additional settings for unpoller. |
 
 For additional configuration use the `extraEnv` section.

--- a/charts/unpoller/values.yaml
+++ b/charts/unpoller/values.yaml
@@ -86,11 +86,11 @@ settings:
       save_dpi: false
       verify_ssl: false
       # role: ""
+      # api_key: ""  # required for Integration/v1 metrics on Network 9.3.43+ (unpoller v3+)
     ## if existing secrets is supplied, below section is ignored
     ## to use in an env variable, use `UP_UNIFI_CONTROLLER_0_{USER/PASS}` in secret key
     auth:
-      ## For a Non UnifiOS Controller (like: https://hub.docker.com/r/linuxserver/unifi-controller):
-      ## Email field will be the `username`
+      ## For the self-hosted UniFi Network Application, email field will be the `username`
       ## change the below to your created user/pass
       user: ""
       pass: ""
@@ -121,7 +121,14 @@ settings:
     # UP_PROMETHEUS_NAMESPACE: "unpoller"
     namespace: "unpoller"
     http_listen: "0.0.0.0:9130"
-    
+
+    ## Background poll interval for Prometheus metric collection (added in unpoller v3.2.0).
+    ## unpoller pre-fetches UniFi data on this interval and serves /metrics from cache.
+    ## Default "60s". Minimum effective value is 15s (values below are clamped by unpoller).
+    ## The background cache cannot be disabled via this setting.
+    ## Align your Prometheus scrape interval with this value to avoid stale data gaps.
+    interval: "60s"
+
     ## additional settings
     # report_errors: false
     # buffer: "50"
@@ -149,6 +156,9 @@ extraEnv: {}
   # UP_UNIFI_CONTROLLER_1_SAVE_SITES: "true"
   ## change the below to your unifi instance
   # UP_UNIFI_CONTROLLER_1_URL: https://unifi.localdomain:8443
+  ## api_key for Integration/v1 metrics (Network 9.3.43+, unpoller v3+)
+  ## Prefer storing this in `existingSecret` as UP_UNIFI_CONTROLLER_0_API_KEY rather than plaintext here
+  # UP_UNIFI_CONTROLLER_0_API_KEY: ""
 
 ## Liveness probe
 ## port: "prom" = .Values.service.port in the deployment file


### PR DESCRIPTION
## Changes

- `Chart.yaml`: version `2.1.0` -> `3.0.0`, appVersion `v2.11.2` -> `v3.2.0`
- `values.yaml`: expose `settings.prometheus.interval` (default `60s`) for unpoller v3.2.0 background polling; add `api_key` comment under `settings.unifi.config` with `existingSecret` guidance
- `README.md`: upgrade matrix entry for `2.X.X` -> `3.0.0` with breaking change summary and upstream release note links; URL guidance for UniFi OS vs self-hosted; `interval` and `api_key` config table entries

## Motivation

Closes/supersedes renovate PR #119. The renovate-generated PR bumped chart version as minor (`2.2.0`) — this is a major due to unpoller v2 -> v3 breaking changes:

- UniFi Network 10.2.105+ removed events and IDS/IPS endpoints; unpoller v2 returns 404, v3 handles gracefully
- unpoller v3.2.0 changed Prometheus scraping to background cache (60s default) — requires chart value and scrape interval alignment

## Verification

- Confirmed `interval` -> `UP_PROMETHEUS_INTERVAL` env var via existing template loop in `deployment.yaml`
- Confirmed `existingSecret` (`envFrom: secretRef`) covers `api_key` without template changes
- Confirmed background cache cannot be disabled via `interval = 0` (clamped to 60s default)
- Reviewed against upgrade matrix convention in `bookstack`, `tdarr-exporter`, `exportarr` charts

## In-depth

unpoller v3 source verified: `normalizeInterval()` clamps values `<= 0` to `defaultInterval` (60s); cache initialized unconditionally. The renovate PR #119 can be closed in favour of this one.