### PR TITLE
docs: nest Migrating under Upgrade, rename matrix to Potential Breaking Updates

### DIFF
--- a/charts/pihole-exporter/README.md
+++ b/charts/pihole-exporter/README.md
@@ -11,7 +11,7 @@ A Helm Chart to deploy a Prometheus [exporter](https://github.com/eko/pihole-exp
 - [Prerequisites](#prerequisites)
 - [Install](#install)
 - [Upgrade](#upgrade)
-- [Migrating to 1.0.0](#migrating-to-100)
+  - [Migrating to 1.0.0](#migrating-to-100)
 - [Configuration Options](#configuration-options)
 - [Grafana Dashboards](#grafana-dashboards)
 - [References](#references)
@@ -81,14 +81,14 @@ helm upgrade pihole-exporter homeylab/pihole-exporter -n pihole-exporter
 helm upgrade -f my-values.yaml pihole-exporter homeylab/pihole-exporter -n pihole-exporter
 ```
 
-### Upgrade Matrix For Releases
-_The matrix below displays certain versions of this helm chart that could result in breaking changes._
+### Potential Breaking Updates
+_The table below lists chart version upgrades that may introduce breaking changes or require manual steps._
 
 | Start Chart Version | Target Chart Version | Upgrade Steps |
 | ------------------- | -------------------- | ------------- |
 | `0.1.X` | `1.0.0` | Hardened `securityContext` defaults and a standardized image schema now apply; credentials move into a chart-managed Secret (behavior-preserving). **Read the [Migrating to 1.0.0](#migrating-to-100) section in full before upgrading.** |
 
-## Migrating to 1.0.0
+### Migrating to 1.0.0
 First major release. Most changes are transparent if you already set `settings.auth.password`/`token` — review the breaking items below before upgrading.
 
 - **Hardened `securityContext` defaults (breaking — motivates the major bump).** The pod now runs with `runAsNonRoot`, `runAsUser: 65534`, `readOnlyRootFilesystem: true`, and `drop: [ALL]`. Fine for the stock `ekofr/pihole-exporter` image; override `podSecurityContext`/`securityContext` if you run a customized one.

--- a/charts/pihole-exporter/README.md.gotmpl
+++ b/charts/pihole-exporter/README.md.gotmpl
@@ -10,7 +10,7 @@ A Helm Chart to deploy a Prometheus [exporter](https://github.com/eko/pihole-exp
 - [Prerequisites](#prerequisites)
 - [Install](#install)
 - [Upgrade](#upgrade)
-- [Migrating to 1.0.0](#migrating-to-100)
+  - [Migrating to 1.0.0](#migrating-to-100)
 - [Configuration Options](#configuration-options)
 - [Grafana Dashboards](#grafana-dashboards)
 - [References](#references)
@@ -80,14 +80,14 @@ helm upgrade pihole-exporter homeylab/pihole-exporter -n pihole-exporter
 helm upgrade -f my-values.yaml pihole-exporter homeylab/pihole-exporter -n pihole-exporter
 ```
 
-### Upgrade Matrix For Releases
-_The matrix below displays certain versions of this helm chart that could result in breaking changes._
+### Potential Breaking Updates
+_The table below lists chart version upgrades that may introduce breaking changes or require manual steps._
 
 | Start Chart Version | Target Chart Version | Upgrade Steps |
 | ------------------- | -------------------- | ------------- |
 | `0.1.X` | `1.0.0` | Hardened `securityContext` defaults and a standardized image schema now apply; credentials move into a chart-managed Secret (behavior-preserving). **Read the [Migrating to 1.0.0](#migrating-to-100) section in full before upgrading.** |
 
-## Migrating to 1.0.0
+### Migrating to 1.0.0
 First major release. Most changes are transparent if you already set `settings.auth.password`/`token` — review the breaking items below before upgrading.
 
 - **Hardened `securityContext` defaults (breaking — motivates the major bump).** The pod now runs with `runAsNonRoot`, `runAsUser: 65534`, `readOnlyRootFilesystem: true`, and `drop: [ALL]`. Fine for the stock `ekofr/pihole-exporter` image; override `podSecurityContext`/`securityContext` if you run a customized one.

--- a/charts/qbittorrent-exporter/README.md
+++ b/charts/qbittorrent-exporter/README.md
@@ -11,7 +11,7 @@ A Helm Chart to deploy a Prometheus [exporter](https://github.com/martabal/qbitt
 - [Prerequisites](#prerequisites)
 - [Install](#install)
 - [Upgrade](#upgrade)
-- [Migrating to 1.0.0](#migrating-to-100)
+  - [Migrating to 1.0.0](#migrating-to-100)
 - [Configuration Options](#configuration-options)
 - [Grafana Dashboards](#grafana-dashboards)
 - [References](#references)
@@ -86,14 +86,14 @@ helm upgrade qbittorrent-exporter homeylab/qbittorrent-exporter -n qbittorrent-e
 helm upgrade -f my-values.yaml qbittorrent-exporter homeylab/qbittorrent-exporter -n qbittorrent-exporter
 ```
 
-### Upgrade Matrix For Releases
-_The matrix below displays certain versions of this helm chart that could result in breaking changes._
+### Potential Breaking Updates
+_The table below lists chart version upgrades that may introduce breaking changes or require manual steps._
 
 | Start Chart Version | Target Chart Version | Upgrade Steps |
 | ------------------- | -------------------- | ------------- |
 | `0.1.X` | `1.0.0` | Backing exporter swapped, hardened `securityContext`, standardized image schema, chart-managed Secret. **Read the [Migrating to 1.0.0](#migrating-to-100) section in full before upgrading.** |
 
-## Migrating to 1.0.0
+### Migrating to 1.0.0
 First major release. This version **swaps the backing exporter image** and hardens the chart. Review all items before upgrading.
 
 - **Backing exporter changed (breaking).** The chart now deploys `martabal/qbittorrent-exporter` (actively maintained, Go) instead of the unmaintained `caseyscarborough/qbittorrent-exporter` (Java, last released 2023). **Metric names and labels differ** — re-import the Grafana dashboard (see below) after upgrading.

--- a/charts/qbittorrent-exporter/README.md.gotmpl
+++ b/charts/qbittorrent-exporter/README.md.gotmpl
@@ -10,7 +10,7 @@ A Helm Chart to deploy a Prometheus [exporter](https://github.com/martabal/qbitt
 - [Prerequisites](#prerequisites)
 - [Install](#install)
 - [Upgrade](#upgrade)
-- [Migrating to 1.0.0](#migrating-to-100)
+  - [Migrating to 1.0.0](#migrating-to-100)
 - [Configuration Options](#configuration-options)
 - [Grafana Dashboards](#grafana-dashboards)
 - [References](#references)
@@ -85,14 +85,14 @@ helm upgrade qbittorrent-exporter homeylab/qbittorrent-exporter -n qbittorrent-e
 helm upgrade -f my-values.yaml qbittorrent-exporter homeylab/qbittorrent-exporter -n qbittorrent-exporter
 ```
 
-### Upgrade Matrix For Releases
-_The matrix below displays certain versions of this helm chart that could result in breaking changes._
+### Potential Breaking Updates
+_The table below lists chart version upgrades that may introduce breaking changes or require manual steps._
 
 | Start Chart Version | Target Chart Version | Upgrade Steps |
 | ------------------- | -------------------- | ------------- |
 | `0.1.X` | `1.0.0` | Backing exporter swapped, hardened `securityContext`, standardized image schema, chart-managed Secret. **Read the [Migrating to 1.0.0](#migrating-to-100) section in full before upgrading.** |
 
-## Migrating to 1.0.0
+### Migrating to 1.0.0
 First major release. This version **swaps the backing exporter image** and hardens the chart. Review all items before upgrading.
 
 - **Backing exporter changed (breaking).** The chart now deploys `martabal/qbittorrent-exporter` (actively maintained, Go) instead of the unmaintained `caseyscarborough/qbittorrent-exporter` (Java, last released 2023). **Metric names and labels differ** — re-import the Grafana dashboard (see below) after upgrading.

--- a/charts/tdarr-exporter/README.md
+++ b/charts/tdarr-exporter/README.md
@@ -13,7 +13,7 @@ This chart is also included as an optional deployment in the [exportarr](https:/
 - [Prerequisites](#prerequisites)
 - [Install](#install)
 - [Upgrade](#upgrade)
-- [Migrating to 2.0.0](#migrating-to-200)
+  - [Migrating to 2.0.0](#migrating-to-200)
 - [Configuration Options](#configuration-options)
 - [Grafana Dashboards](#grafana-dashboards)
 - [References](#references)
@@ -82,15 +82,15 @@ helm upgrade tdarr-exporter homeylab/tdarr-exporter -n tdarr-exporter
 helm upgrade -f my-values.yaml tdarr-exporter homeylab/tdarr-exporter -n tdarr-exporter
 ```
 
-### Upgrade Matrix For Releases
-_The matrix below displays certain versions of this helm chart that could result in breaking changes._
+### Potential Breaking Updates
+_The table below lists chart version upgrades that may introduce breaking changes or require manual steps._
 
 | Start Chart Version | Target Chart Version | Upgrade Steps |
 | ------------------- | -------------------- | ------------- |
 | `1.X.X` | `2.0.0` | Hardened `securityContext`, standardized image schema, chart-managed Secret for the inline API key, and `appVersion` bumped to the current upstream `v3.0.0` image. **Read the [Migrating to 2.0.0](#migrating-to-200) section in full before upgrading.** |
 | `1.1.X` | `1.2.0` | Exporter upgraded to upstream `v2.x` (`appVersion` `1.4.3` -> `2.1.0`). No chart configuration changes. This is a breaking _upstream_ release: it requires Tdarr `v2.24.01`+ and renames/removes many Prometheus metrics and labels, so existing dashboards and alerts will break. Review the [upstream v2.0.0 release notes](https://github.com/homeylab/tdarr-exporter/releases/tag/v2.0.0) and reimport the [Grafana dashboard](https://grafana.com/grafana/dashboards/20388-tdarr/) before upgrading. |
 
-## Migrating to 2.0.0
+### Migrating to 2.0.0
 This version hardens the chart and standardizes its schema to match the other homeylab exporter charts, and moves `appVersion` to the current upstream image. The image repository is unchanged (still `homeylab/tdarr-exporter`). Review all items before upgrading.
 
 - **Image schema standardized (breaking).** `image.name` is renamed to `image.repository`; the previous `image.repository` (the registry host) is now `image.registry`. No image change — still `docker.io/homeylab/tdarr-exporter`.

--- a/charts/tdarr-exporter/README.md.gotmpl
+++ b/charts/tdarr-exporter/README.md.gotmpl
@@ -12,7 +12,7 @@ This chart is also included as an optional deployment in the [exportarr](https:/
 - [Prerequisites](#prerequisites)
 - [Install](#install)
 - [Upgrade](#upgrade)
-- [Migrating to 2.0.0](#migrating-to-200)
+  - [Migrating to 2.0.0](#migrating-to-200)
 - [Configuration Options](#configuration-options)
 - [Grafana Dashboards](#grafana-dashboards)
 - [References](#references)
@@ -81,15 +81,15 @@ helm upgrade tdarr-exporter homeylab/tdarr-exporter -n tdarr-exporter
 helm upgrade -f my-values.yaml tdarr-exporter homeylab/tdarr-exporter -n tdarr-exporter
 ```
 
-### Upgrade Matrix For Releases
-_The matrix below displays certain versions of this helm chart that could result in breaking changes._
+### Potential Breaking Updates
+_The table below lists chart version upgrades that may introduce breaking changes or require manual steps._
 
 | Start Chart Version | Target Chart Version | Upgrade Steps |
 | ------------------- | -------------------- | ------------- |
 | `1.X.X` | `2.0.0` | Hardened `securityContext`, standardized image schema, chart-managed Secret for the inline API key, and `appVersion` bumped to the current upstream `v3.0.0` image. **Read the [Migrating to 2.0.0](#migrating-to-200) section in full before upgrading.** |
 | `1.1.X` | `1.2.0` | Exporter upgraded to upstream `v2.x` (`appVersion` `1.4.3` -> `2.1.0`). No chart configuration changes. This is a breaking _upstream_ release: it requires Tdarr `v2.24.01`+ and renames/removes many Prometheus metrics and labels, so existing dashboards and alerts will break. Review the [upstream v2.0.0 release notes](https://github.com/homeylab/tdarr-exporter/releases/tag/v2.0.0) and reimport the [Grafana dashboard](https://grafana.com/grafana/dashboards/20388-tdarr/) before upgrading. |
 
-## Migrating to 2.0.0
+### Migrating to 2.0.0
 This version hardens the chart and standardizes its schema to match the other homeylab exporter charts, and moves `appVersion` to the current upstream image. The image repository is unchanged (still `homeylab/tdarr-exporter`). Review all items before upgrading.
 
 - **Image schema standardized (breaking).** `image.name` is renamed to `image.repository`; the previous `image.repository` (the registry host) is now `image.registry`. No image change — still `docker.io/homeylab/tdarr-exporter`.


### PR DESCRIPTION
## Changes
For `qbittorrent-exporter`, `tdarr-exporter`, and `pihole-exporter`:
- Move each `## Migrating to X.Y.Z` heading to `### Migrating to X.Y.Z`, nested under `## Upgrade`, and indent the Table of Contents bullet under Upgrade.
- Rename `### Upgrade Matrix For Releases` to `### Potential Breaking Updates` and reword its caption to drop "matrix" jargon.

Docs-only — **no chart version bumps**. The `#migrating-to-*` anchors are heading-level-independent, so the matrix-row "Read the Migrating..." links still resolve; nothing links to the renamed section anchor.

## Motivation
Migration notes are part of the upgrade path, so grouping them under `## Upgrade` keeps each chart's top-level Table of Contents lean. "Potential Breaking Updates" states the section's purpose plainly (which versions can break on upgrade) versus the vaguer "Upgrade Matrix For Releases". Establishes the convention already applied to `exportarr` in #137.

## Test plan
- `task docs APP=<chart>` regenerated each README from its `.gotmpl`; confirmed `### Migrating`, `### Potential Breaking Updates`, indented TOC bullet, and intact matrix-row anchors.

## In-depth
Published ArtifactHub READMEs update on each chart's next release (chart-releaser only republishes on a version change); the GitHub source READMEs are consistent immediately, which is the point of this cosmetic pass.

`bookstack` is intentionally excluded: its Upgrade hierarchy is already irregular (`## Upgrades`, `#### Upgrade Matrix For Releases`, and a `## Migrating to 5.0.0` that owns several `###`/`####` sub-headings), so flipping and renaming it cascades sub-heading levels and warrants a deliberate cleanup rather than a drive-by.