### PR TITLE
feat(ci): add PR-level chart-testing gate

### DIFF
--- a/.github/ct/chart_schema.yaml
+++ b/.github/ct/chart_schema.yaml
@@ -1,0 +1,37 @@
+name: str()
+home: str(required=False)
+version: str()
+apiVersion: str()
+appVersion: any(str(), num(), required=False)
+description: str(required=False)
+keywords: list(str(), required=False)
+sources: list(str(), required=False)
+maintainers: list(include('maintainer'), required=False)
+dependencies: list(include('dependency'), required=False)
+icon: str(required=False)
+engine: str(required=False)
+condition: str(required=False)
+tags: str(required=False)
+deprecated: bool(required=False)
+kubeVersion: str(required=False)
+annotations: map(str(), str(), required=False)
+type: str(required=False)
+---
+maintainer:
+  name: str()
+  email: str(required=False)
+  url: str(required=False)
+---
+dependency:
+  name: str()
+  version: str()
+  repository: str(required=False)
+  condition: str(required=False)
+  tags: list(str(), required=False)
+  enabled: bool(required=False)
+  import-values: list(any(str(), include('import-value')), required=False)
+  alias: str(required=False)
+---
+import-value:
+  child: str()
+  parent: str()

--- a/.github/ct/ct.yaml
+++ b/.github/ct/ct.yaml
@@ -1,0 +1,16 @@
+# chart-testing config — the single source of truth for CI validation.
+# Local dev: `ct lint --config .github/ct/ct.yaml [--charts charts/<name>]`
+target-branch: main
+chart-dirs:
+  - charts
+chart-yaml-schema: .github/ct/chart_schema.yaml
+lint-conf: .github/ct/lintconf.yaml
+# We don't require maintainer names to be real GitHub accounts.
+validate-maintainers: false
+# Fail a PR that changes a chart without bumping Chart.yaml version (chart-releaser
+# silently skips unbumped charts, so this gate prevents "shipped nothing" merges).
+check-version-increment: true
+# ct runs these as bare argv per changed chart (NO shell — no pipes). {{ .Path }} = chart dir.
+additional-commands:
+  - "helm unittest {{ .Path }}"
+  - "bash scripts/ci/kubeconform.sh {{ .Path }}"

--- a/.github/ct/lintconf.yaml
+++ b/.github/ct/lintconf.yaml
@@ -1,0 +1,42 @@
+---
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    require-starting-space: true
+    min-spaces-from-content: 2
+  document-end: disable
+  document-start: disable           # No --- to start a file
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: consistent
+    indent-sequences: whatever      # - list indentation will handle both indentation and without
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length: disable              # Lines can be any length
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  trailing-spaces: enable
+  truthy:
+    level: warning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+permissions: {}
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint-test:
+    name: Lint and unit-test changed charts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0            # ct needs history to diff against main
+          persist-credentials: false
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          # renovate: github=helm/helm
+          version: v4.2.3
+
+      - name: Set up Python
+        # ct's yamllint + yamale need Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.x'
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+        with:
+          # renovate: github=helm/chart-testing
+          version: v3.14.0
+
+      - name: Install helm-unittest plugin
+        env:
+          # renovate: github=helm-unittest/helm-unittest
+          UNITTEST_VERSION: v1.1.1
+        # Helm 4 verifies plugin sources by default; unsigned git installs need --verify=false
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version "${UNITTEST_VERSION#v}" --verify=false
+
+      - name: Install kubeconform
+        env:
+          # renovate: github=yannh/kubeconform
+          KUBECONFORM_VERSION: v0.8.0
+        run: |
+          curl -fsSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin kubeconform
+
+      - name: List changed charts
+        id: list-changed
+        run: |
+          changed="$(ct list-changed --config .github/ct/ct.yaml)"
+          if [ -n "$changed" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            printf 'Changed charts:\n%s\n' "$changed"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No charts changed."
+          fi
+
+      - name: Lint (version gate + yamllint/yamale + unittest + kubeconform)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --config .github/ct/ct.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ kube_config
 .DS_Store
 
 .claude/
+
+# Locally packaged charts (task pkg / pkg-with-dep)
+/*.tgz

--- a/scripts/ci/kubeconform.sh
+++ b/scripts/ci/kubeconform.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Render a chart and validate the manifests against Kubernetes schemas.
+# Usage: scripts/ci/kubeconform.sh <chart-dir>   (chart-dir e.g. charts/pihole-exporter)
+# Mirrors `task kubeconform`. Invoked per-chart by ct via ct.yaml additional-commands.
+set -euo pipefail
+
+chart="$1"
+helm template "$(basename "$chart")" "$chart" \
+  | kubeconform -strict -summary -ignore-missing-schemas -kubernetes-version 1.30.0


### PR DESCRIPTION
## Changes

Adds a PR-level `chart-testing` (`ct`) gate — the repo's first pre-merge CI. Previously `release.yml` (push-to-main) was the only workflow, so nothing validated charts before merge.

- `.github/workflows/ci.yml` — `on: pull_request` → `main`; single `lint-test` job. Runs `ct list-changed` then, only if charts changed, `ct lint`. Third-party actions SHA-pinned with `# renovate:` comments; helm/ct/kubeconform/helm-unittest versions env-pinned with renovate comments.
- `.github/ct/ct.yaml` — single source of truth for CI validation. `ct lint` = helm-lint + yamllint + yamale schema + `--check-version-increment` gate, plus kubeconform + helm-unittest folded in via `additional-commands`.
- `.github/ct/{chart_schema.yaml,lintconf.yaml}` — vendored canonical configs `ct lint` requires (the GitHub action bundles them; direct/local runs need them present).
- `scripts/ci/kubeconform.sh` — render-and-validate wrapper. `ct` runs `additional-commands` as bare argv with no shell, so the `helm template | kubeconform` pipe must live in a script.
- `.gitignore` — ignore root `/*.tgz` (package artifact from `task pkg-with-dep`).

CI is **`ct`-direct**, not routed through the Taskfile (mirrors prometheus-community / grafana). Taskfile stays local-dev only.

## Motivation

- No pre-merge validation existed; regressions could only surface post-merge in `release.yml`.
- The `--check-version-increment` gate enforces a chart `version` bump on any chart change — without a bump, `chart-releaser` silently skips the release. The gate turns that silent no-op into a red PR.

## Test plan

Verified locally (helm 4.2.1, ct 3.14.0):
- `ct lint` on a no-dep chart (pihole-exporter) → all stages pass (yamale, yamllint, unittest, kubeconform, helm-lint), RC=0.
- `ct lint` on dependency charts (bookstack, exportarr) → deps resolve via `helm dependency build` before `additional-commands`; unittest + kubeconform run green, RC=0.
- version-increment gate: no bump → FAIL (`Needs a version bump!`); bump → PASS.
- `helm plugin install ... --verify=false` confirmed required + working under Helm 4.

Note: this PR touches no chart dirs, so its own gate runs as a green no-op (nothing changed to lint). The gate exercises on the next chart PR.

## In-depth

- **`--verify=false` on the plugin install** is required under Helm 4, which verifies plugin sources by default and aborts unsigned git installs.
- Follow-ups (separate PRs): require the `lint-test` check via branch protection (admin step); `file://` subchart deps to fix the co-bump release race; phased kind `ct install`; align `release.yml` helm pin (v4.2.2 → v4.2.3).
