### PR TITLE
fix: omit PVC storageClassName when unset (v-rising, bookstack-file-exporter)

### DIFF
--- a/charts/bookstack-file-exporter/Chart.yaml
+++ b/charts/bookstack-file-exporter/Chart.yaml
@@ -18,7 +18,7 @@ maintainers:
     url: https://github.com/homeylab
 
 # This is the chart version. SemVer: https://semver.org/
-version: 1.0.0
+version: 1.0.1
 
 # Application version (upstream image tag). Not SemVer-bound.
 # renovate: datasource=docker depName=homeylab/bookstack-file-exporter
@@ -30,21 +30,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/homeylab/helm-charts/tree/main/charts/bookstack-file-exporter
   artifacthub.io/changes: |
-    - kind: changed
-      description: "BREAKING - appVersion bumped 2.1.0 -> 3.0.0 (current upstream homeylab/bookstack-file-exporter image); the v3 config schema is a breaking rewrite from v2"
-    - kind: changed
-      description: "BREAKING - config.minio (single object) replaced by config.object_storage (list); values + rendered config.yml both change shape"
-    - kind: changed
-      description: "BREAKING - inner config: values are now snake_case, matching the upstream config.yml 1:1 (e.g. credentials.token_id, assets.modify_links, http_config.verify_ssl); previously camelCase keys were hand-mapped to snake_case, a mismap-prone translation layer that is now removed"
-    - kind: changed
-      description: "BREAKING - image schema standardized: image.repository (previously the registry host) + image.name (previously the image path) replaced by image.registry + image.repository, matching the other homeylab exporter charts"
     - kind: fixed
-      description: "cronjob.yaml timeZone bug fixed: the CronJob's timeZone previously read a nonexistent .Values.timeZone and silently never rendered; it now correctly reads cron.timeZone"
-    - kind: added
-      description: "config.existingConfigMap escape hatch: mount your own ConfigMap for config.yml (e.g. GitOps-managed, or upstream keys not yet modeled) instead of the chart-rendered one"
-    - kind: changed
-      description: "the rendered config.yml now prunes unset/empty keys instead of always emitting every field, since v3 rejects unknown keys and explicit null values"
-    - kind: changed
-      description: "config.run_schedule (upstream app-native cron) is intentionally unsupported and not exposed as a values key; the chart fails fast with a helpful error if set, since it cannot fire under CronJob mode and is redundant under Deployment mode - use config.run_interval: 0 + cron.schedule, or config.run_interval > 0 instead"
-    - kind: changed
-      description: "graduated to 1.0.0; chart is now enrolled in helm-docs and helm-unittest"
+      description: "PVC storageClassName is now omitted when persistence.storageClass is unset (the default) so the cluster's default StorageClass provisions; previously it rendered storageClassName: \"\", which disables dynamic provisioning and left the Deployment-mode PVC Pending"

--- a/charts/bookstack-file-exporter/templates/pvc.yaml
+++ b/charts/bookstack-file-exporter/templates/pvc.yaml
@@ -21,7 +21,7 @@ spec:
       storage: {{ .Values.persistence.size | quote }}
   {{- if (eq "-" .Values.persistence.storageClass) }}
   storageClassName: ""
-  {{- else }}
+  {{- else if .Values.persistence.storageClass }}
   storageClassName: "{{ .Values.persistence.storageClass }}"
   {{- end }}
   {{- with .Values.persistence.selector }}

--- a/charts/bookstack-file-exporter/tests/pvc_test.yaml
+++ b/charts/bookstack-file-exporter/tests/pvc_test.yaml
@@ -1,0 +1,32 @@
+suite: bookstack-file-exporter PVC
+templates:
+  - templates/pvc.yaml
+release:
+  name: bookstack-file-exporter
+tests:
+  - it: does not render when persistence is disabled (default)
+    asserts:
+      - hasDocuments: { count: 0 }
+  - it: renders a PVC when persistence is enabled
+    set:
+      persistence.enabled: true
+    asserts:
+      - hasDocuments: { count: 1 }
+      - equal: { path: spec.resources.requests.storage, value: 5Gi }
+  - it: omits storageClassName when storageClass is unset (default provisioner)
+    set:
+      persistence.enabled: true
+    asserts:
+      - notExists: { path: spec.storageClassName }
+  - it: disables dynamic provisioning when storageClass is "-"
+    set:
+      persistence.enabled: true
+      persistence.storageClass: "-"
+    asserts:
+      - equal: { path: spec.storageClassName, value: "" }
+  - it: sets storageClassName when storageClass is a class name
+    set:
+      persistence.enabled: true
+      persistence.storageClass: nfs-provisioner
+    asserts:
+      - equal: { path: spec.storageClassName, value: nfs-provisioner }

--- a/charts/v-rising/Chart.yaml
+++ b/charts/v-rising/Chart.yaml
@@ -18,7 +18,7 @@ maintainers:
     url: https://github.com/homeylab
 
 # This is the chart version. SemVer: https://semver.org/
-version: 1.0.0
+version: 1.0.1
 
 # Application version (upstream image tag). Not SemVer-bound.
 # renovate: datasource=docker depName=trueosiris/vrising versioning=regex:^(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+))?$
@@ -30,15 +30,5 @@ annotations:
     - name: Chart Source
       url: https://github.com/homeylab/helm-charts/tree/main/charts/v-rising
   artifacthub.io/changes: |
-    - kind: changed
-      description: "BREAKING - image schema standardized: added image.registry (docker.io); image.repository unchanged (trueosiris/vrising)"
     - kind: fixed
-      description: "BREAKING - rcon Service renamed from the chart fullname to <fullname>-rcon, fixing a name collision with the main Service when service.rcon.enabled is true"
-    - kind: removed
-      description: "BREAKING - removed the dead/broken Ingress (referenced a nonexistent service.port, and the game protocol is UDP which L7 ingress cannot route); expose the server via the existing LoadBalancer/NodePort Service instead"
-    - kind: fixed
-      description: "config env vars no longer emit empty values (e.g. BRANCH=\"\") when left unset"
-    - kind: added
-      description: "updateStrategy value (default Recreate) to avoid a ReadWriteOnce PVC multi-attach deadlock on upgrade"
-    - kind: changed
-      description: "graduated to 1.0.0; chart is now enrolled in helm-docs and helm-unittest"
+      description: "PVC storageClassName is now omitted when persistence.*.storageClass is unset (the default) so the cluster's default StorageClass provisions; previously it rendered storageClassName: \"\", which disables dynamic provisioning and left the PVCs Pending"

--- a/charts/v-rising/ci/ct-values.yaml
+++ b/charts/v-rising/ci/ct-values.yaml
@@ -1,0 +1,13 @@
+# ct install permutation: trims the game server's memory request so the pod
+# schedules on the free 2vCPU/7GB CI runner (the shipped default 6G is sized for
+# real gameplay, not a smoke test). No health endpoint upstream, so there is no
+# readiness probe — the pod reaches Ready once the container is running.
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+persistence:
+  steamServer:
+    size: 1Gi
+  world:
+    size: 1Gi

--- a/charts/v-rising/templates/server-files-pvc.yaml
+++ b/charts/v-rising/templates/server-files-pvc.yaml
@@ -21,7 +21,7 @@ spec:
       storage: {{ .Values.persistence.steamServer.size | quote }}
 {{- if (eq "-" .Values.persistence.steamServer.storageClass) }}
   storageClassName: ""
-{{- else }}
+{{- else if .Values.persistence.steamServer.storageClass }}
   storageClassName: "{{ .Values.persistence.steamServer.storageClass }}"
 {{- end }}
   {{- if .Values.persistence.steamServer.selector }}

--- a/charts/v-rising/templates/world-files-pvc.yaml
+++ b/charts/v-rising/templates/world-files-pvc.yaml
@@ -21,7 +21,7 @@ spec:
       storage: {{ .Values.persistence.world.size | quote }}
 {{- if (eq "-" .Values.persistence.world.storageClass) }}
   storageClassName: ""
-{{- else }}
+{{- else if .Values.persistence.world.storageClass }}
   storageClassName: "{{ .Values.persistence.world.storageClass }}"
 {{- end }}
   {{- if .Values.persistence.world.selector }}

--- a/charts/v-rising/tests/server-files-pvc_test.yaml
+++ b/charts/v-rising/tests/server-files-pvc_test.yaml
@@ -19,3 +19,16 @@ tests:
       persistence.steamServer.enabled: false
     asserts:
       - hasDocuments: { count: 0 }
+  - it: omits storageClassName when storageClass is unset (default provisioner)
+    asserts:
+      - notExists: { path: spec.storageClassName }
+  - it: disables dynamic provisioning when storageClass is "-"
+    set:
+      persistence.steamServer.storageClass: "-"
+    asserts:
+      - equal: { path: spec.storageClassName, value: "" }
+  - it: sets storageClassName when storageClass is a class name
+    set:
+      persistence.steamServer.storageClass: fast-ssd
+    asserts:
+      - equal: { path: spec.storageClassName, value: fast-ssd }

--- a/charts/v-rising/tests/world-files-pvc_test.yaml
+++ b/charts/v-rising/tests/world-files-pvc_test.yaml
@@ -19,3 +19,16 @@ tests:
       persistence.world.enabled: false
     asserts:
       - hasDocuments: { count: 0 }
+  - it: omits storageClassName when storageClass is unset (default provisioner)
+    asserts:
+      - notExists: { path: spec.storageClassName }
+  - it: disables dynamic provisioning when storageClass is "-"
+    set:
+      persistence.world.storageClass: "-"
+    asserts:
+      - equal: { path: spec.storageClassName, value: "" }
+  - it: sets storageClassName when storageClass is a class name
+    set:
+      persistence.world.storageClass: fast-ssd
+    asserts:
+      - equal: { path: spec.storageClassName, value: fast-ssd }


### PR DESCRIPTION
## Changes

Fixes a PVC-template footgun in two charts and bumps each a patch (`1.0.0 → 1.0.1`):

- **v-rising** — `templates/{server-files,world-files}-pvc.yaml`. Also adds a `ct install` scenario (`ci/ct-values.yaml`, trimmed memory request) and `storageClassName` regression unittests.
- **bookstack-file-exporter** — `templates/pvc.yaml`. Adds a PVC unittest suite.

Both templates rendered `storageClassName` unconditionally in the `else` branch, so the default `storageClass: ""` produced `storageClassName: ""` — which **disables dynamic provisioning** and leaves the PVC `Pending` on any cluster relying on a default StorageClass. The `values.yaml` comment ("undefined/null → default provisioner") described behavior no code path implemented. Fix: `{{- else if .storageClass }}` so an unset value **omits** the key (default provisioner), `"-"` still renders `""` (explicit disable), a class name still sets it.

bookstack-file-exporter was the more consequential of the two: its existing `ci/deployment-values.yaml` (`persistence.enabled: true`, no `storageClass`) already rendered `storageClassName: ""`, so its Deployment permutation would hang `Pending` under `ct install`.

bookstack (umbrella) already used the correct `{{- if .storageClass }}` guard and is unchanged.

## Motivation

Surfaced while validating the upcoming kind `ct install` integration tier: v-rising's and bookstack-file-exporter's PVCs never bind on a default-StorageClass cluster (kind included). This is also a real bug for end users on those charts.

## Test plan

- `task verify APP=v-rising` and `task verify APP=bookstack-file-exporter` — both green (lint + kubeconform + unittest, incl. the new `storageClassName` cases: omit-on-unset, `""`-on-`-`, set-on-value).
- Rendering spot-checks: default omits `storageClassName`; `storageClass: "-"` → `""`; `storageClass: <name>` → set — all three templates.
- `ct install` on kind (isolated kubeconfig): v-rising both PVCs **Bound** to the default `standard` class; bookstack-file-exporter Deployment permutation PVC **Bound**, pod `1/1 Running` — previously `Pending`.

## In-depth

Independent charts → two scoped commits, one patch bump each. Safe to release together: v-rising is standalone, and bookstack pins `bookstack-file-exporter` at exact `version: "1.0.0"` (already on OCI), so the OCI package job resolves that published version — no co-bump release race (this PR does not touch bookstack's dependency pin).
