### PR TITLE
feat(ci): add kind ct install to the PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,14 @@ jobs:
       - name: Lint (version gate + yamllint/yamale + unittest + kubeconform)
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --config .github/ct/ct.yaml
+
+      - name: Create kind cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+
+      # Integration tier: prove changed charts install and reach Ready on a real cluster.
+      # nut-exporter is deprecated (still linted above, just not installed) — exclude it here
+      # only, via the CLI flag, so the shared ct.yaml keeps covering it for lint.
+      - name: Install changed charts (ct install on kind)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --config .github/ct/ct.yaml --excluded-charts nut-exporter --helm-extra-args "--timeout 600s"


### PR DESCRIPTION
## Changes

- Extend the `lint-test` job in `.github/workflows/ci.yml` with two steps, both gated on the existing `list-changed` output:
  - **Create kind cluster** via `helm/kind-action` (SHA-pinned to v1.14.0).
  - **Install changed charts** via `ct install --config .github/ct/ct.yaml --excluded-charts nut-exporter --helm-extra-args "--timeout 600s"`.
- Steps are added to the existing job (not a new one), so the required branch-protection check `Lint and unit-test changed charts` is unchanged.

## Motivation

PR-level CI so far only lints and renders charts (`ct lint`). This adds an integration tier: changed charts must actually **install and reach Ready** on a real cluster, catching failures that render-time checks miss (bad probes, image pull, PVC provisioning, wiring).

`nut-exporter` is deprecated and excluded from install via the `--excluded-charts` CLI flag **on this step only** — the shared `.github/ct/ct.yaml` is untouched, so `ct lint` still covers nut-exporter. `kubeconform` (in the lint step) stays as the cheap fast pre-check ahead of the heavier install.

## Test plan

- kind-action SHA verified against tag v1.14.0; pin style matches the other actions in this workflow.
- Local proof on an isolated kind cluster: `ct install --config .github/ct/ct.yaml --excluded-charts nut-exporter --charts charts/pihole-exporter` — chart installed, reached Ready, `helm test` pod Completed. Confirms `ct install` accepts the lint-oriented `ct.yaml` config.
- This PR changes no chart directory, so `list-changed` is false and the install step is a no-op here; its first live exercise is the next chart PR.

## In-depth

- Do **not** rename the `lint-test` job or its `name:` — that display name is the required status-check context; renaming silently breaks branch protection.
- Watch-item for the first real chart PR through this gate: confirm `helm test` and teardown complete on the GitHub runner (a local WSL2 run saw `helm uninstall --wait` hang in teardown, attributed to WSL2-kind flakiness, not the chart).