### PR TITLE
fix(ci): wire Renovate to track workflow tool versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,14 @@
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Track CI/release tool versions pinned in workflow files (helm, chart-testing, helm-unittest, kubeconform). Covers both `with: version:` inputs and `*_VERSION` env vars; the built-in github-actions manager only handles `uses:` refs.",
+      "managerFilePatterns": [".github/workflows/*.yml"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?(?: extractVersion=(?<extractVersion>\\S+))?\\s+(?:[A-Za-z0-9_]+_VERSION|version)\\s*:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
+      ]
     }
   ],
   "packageRules": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
-          # renovate: github=helm/helm
+          # renovate: datasource=github-releases depName=helm/helm
           version: v4.2.3
 
       - name: Set up Python
@@ -34,19 +34,19 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
         with:
-          # renovate: github=helm/chart-testing
+          # renovate: datasource=github-releases depName=helm/chart-testing
           version: v3.14.0
 
       - name: Install helm-unittest plugin
         env:
-          # renovate: github=helm-unittest/helm-unittest
+          # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
           UNITTEST_VERSION: v1.1.1
         # Helm 4 verifies plugin sources by default; unsigned git installs need --verify=false
         run: helm plugin install https://github.com/helm-unittest/helm-unittest --version "${UNITTEST_VERSION#v}" --verify=false
 
       - name: Install kubeconform
         env:
-          # renovate: github=yannh/kubeconform
+          # renovate: datasource=github-releases depName=yannh/kubeconform
           KUBECONFORM_VERSION: v0.8.0
         run: |
           curl -fsSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5.0.1
         with:
-          version: v4.2.2 # default is latest (stable)
+          # renovate: datasource=github-releases depName=helm/helm
+          version: v4.2.3
         # id: install
       - name: Helm Registry Login
         run: echo ${{ secrets.DOCKERHUB_TOKEN }} | helm registry login registry-1.docker.io --password-stdin -u ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Changes

- **`.github/renovate.json`** — add a second `customManagers` regex entry scoped to `.github/workflows/*.yml`. It captures both `with: version:` inputs (helm, chart-testing) and `*_VERSION:` env vars (helm-unittest, kubeconform) via the `# renovate: datasource=... depName=...` annotation. Mirrors the existing appVersion custom manager's conventions.
- **`.github/workflows/ci.yml`** — rewrite the 4 pin annotations from `# renovate: github=<repo>` to `# renovate: datasource=github-releases depName=<repo>`. Comment-only; no version values change.
- **`.github/workflows/release.yml`** — align helm `v4.2.2` → `v4.2.3` (matches ci.yml) and add the same annotation so the pin is managed.

## Motivation

The `# renovate: github=<repo>` comments were **inert** — Renovate has no built-in annotation that consumes them and no custom manager was scoped to the workflow files, so the helm / chart-testing / helm-unittest / kubeconform pins were unmanaged and silently drifted (release.yml's helm was still `v4.2.2` while ci.yml had moved to `v4.2.3`). This wires those pins to `github-releases` so Renovate opens update PRs going forward — relevant now that the PR gate runs a helm-version-sensitive `ct install` step.

The built-in `github-actions` manager (which handles `uses:` SHA-pins) is unaffected; it does not read `with: version:` inputs.

## Test plan / verification

- `renovate-config-validator` (via `renovate/renovate:latest` docker) → `Config validated successfully`.
- Regex extraction test against both workflow files → captures exactly the 5 intended pins with correct datasource/depName/value, no over-match on `uses:` refs, `python-version`, or chart appVersions.
- `github-releases` confirmed correct (not `github-tags`) — all four tools publish GitHub Releases; current pins match latest tags.
- `.github/`-only change (no `charts/**` touched) → `ct list-changed` finds nothing → PR gate self-no-ops; no chart-version bump required.

## In-depth

Declined as low-value: `*.{yml,yaml}` glob (repo convention hardcodes the extension, e.g. `Chart.yaml`; only `.yml` workflows exist), explicit `versioning=semver` (github-releases already defaults to semver and all pins are `v`-prefixed), and forcing these into the `github-actions` update group (custom-manager deps land as separate PRs — cosmetic).

Follow-up (separate, out of scope): release.yml still uses floating `@v5.0.1` action tags rather than SHA pins — tracked under the SHA-pin hygiene item.