### PR TITLE
fix(ci): SHA-pin GitHub Actions in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true # https://github.com/helm/chart-releaser-action/issues/97
@@ -31,7 +31,7 @@ jobs:
     environment: 'dockerhub' 
     steps:
       - name: Install Helm
-        uses: azure/setup-helm@v5.0.1
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           # renovate: datasource=github-releases depName=helm/helm
           version: v4.2.3
@@ -39,9 +39,9 @@ jobs:
       - name: Helm Registry Login
         run: echo ${{ secrets.DOCKERHUB_TOKEN }} | helm registry login registry-1.docker.io --password-stdin -u ${{ secrets.DOCKERHUB_USERNAME }}
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Task
-        uses: go-task/setup-task@v2
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Helm Package Charts


### PR DESCRIPTION
## Changes

Pin all four GitHub Actions in `.github/workflows/release.yml` from mutable tags to immutable commit SHAs (version kept in a trailing `# vX.Y.Z` comment):

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` (×2) | `@v7` | `@9c091bb… # v7.0.0` |
| `helm/chart-releaser-action` | `@v1.7.0` | `@cae68fe… # v1.7.0` |
| `azure/setup-helm` | `@v5.0.1` | `@9bc31f4… # v5.0.1` |
| `go-task/setup-task` | `@v2` | `@01a4adf… # v2.1.0` |

Two refs resolve to a concrete release in the process: floating `@v7` → `v7.0.0` (matches ci.yml) and floating `@v2` → `v2.1.0` (latest v2.x).

## Motivation

`ci.yml` already SHA-pins every action; `release.yml` did not. Mutable tags can be force-moved by a maintainer — or an attacker who compromises the action's repo — to point at different code, which the workflow then runs. `release.yml` handles `DOCKERHUB_TOKEN` and publishes charts, so it is the higher-value target of the two. Pinning to a commit SHA freezes the exact code; the trailing version comment keeps it human-readable and lets Renovate's `github-actions` manager bump the SHA + comment together.

## Test plan / verification

- Every pinned SHA resolved via `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha` and confirmed to equal its claimed tag exactly (independently re-verified in review).
- Shared pins (checkout, setup-helm) are byte-identical to `ci.yml`.
- `python3 yaml.safe_load` → valid; comment format matches the ci.yml convention Renovate parses.
- `.github/`-only change (no `charts/**`) → `ct list-changed` finds nothing → PR gate self-no-ops; no chart-version bump required.

## In-depth

This closes the release.yml supply-chain hygiene gap tracked alongside the CI modernization work. Out of scope / no longer needed: the previously-noted `go-task/setup-task@v2→v2.1.0` bump is folded in here as part of the pin. helm-version drift and the Renovate workflow-tool-version coverage were handled separately (helm now v4.2.3; Renovate now tracks the tool pins).