### PR TITLE
docs(contributing): document umbrella-chart release ordering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,12 @@ Pipeline:
 
 **Consequence:** a templates-only change with an unchanged `version` ships **nothing** via chart-releaser. Always bump `version` when you want a release.
 
+### Umbrella charts: release the subchart first
+
+Two charts bundle **first-party** subcharts from the OCI registry — `bookstack` (→ `bookstack-file-exporter`) and `exportarr` (→ `qbittorrent-exporter`, `tdarr-exporter`). At release, `release.yml` packages the parent by pulling those subcharts *from OCI*, but the job that pushes subcharts to OCI runs later in the same run. So bumping a subchart **and** the parent's dependency on it in one merge fails — the parent can't find the not-yet-published subchart version, and the **whole release aborts** (not just that chart).
+
+**Rule:** ship the subchart bump in its own PR first (it lands in OCI + Pages), then bump the parent's `dependencies[].version` to match in a follow-up PR. `mariadb` is third-party and already published, so it needs no ordering.
+
 **Artifact Hub annotations** (`artifacthub.io/*` in `Chart.yaml`) are catalog metadata for [artifacthub.io](https://artifacthub.io) — **ignored by Helm and the release pipeline** (they never affect rendering, install, or whether a release ships). Not every chart carries them yet. On charts that do, refresh `artifacthub.io/changes` for each release — a list of `{kind, description}` entries where `kind` is one of `added`, `changed`, `deprecated`, `removed`, `fixed`, `security` (Artifact Hub renders these as the version's changelog; `security` entries also trigger a notification). `artifacthub.io/license` and `artifacthub.io/links` rarely change.
 
 ## Gotchas


### PR DESCRIPTION
## Changes

Add a **"Umbrella charts: release the subchart first"** subsection under *Versioning and release* in `CONTRIBUTING.md`. It documents the release-ordering rule for the two charts with first-party subchart dependencies (`bookstack` → `bookstack-file-exporter`; `exportarr` → `qbittorrent-exporter`, `tdarr-exporter`).

## Motivation

`release.yml` packages a parent chart by pulling its subcharts from the OCI registry, but the subcharts are pushed to OCI later in the same run. Bumping a subchart **and** the parent's dependency on it in a single merge therefore fails — the parent can't resolve the not-yet-published subchart version, and the **entire release aborts**. This has bitten before (a co-bump was co-merged and had to be recovered by reverting the parent, releasing the subchart, then re-applying the parent bump).

Until now the fix was tribal knowledge ("release the subchart first"). This makes it an explicit, discoverable rule so contributors don't re-trip it.

This is the standard, low-overhead way monorepos handle same-run subchart+parent co-bumps (release in dependency order across separate PRs), chosen over automating in-pipeline ordering or switching to `file://` local deps — both of which carry larger tradeoffs for published charts.

## Test plan / verification

Docs-only change (no `charts/**` touched) → `ct list-changed` finds nothing → the PR CI gate self-no-ops. Rendered the new subsection to confirm formatting; no TOC change needed (it's a `###` subsection, consistent with the other subsections that are not indexed).