### PR TITLE
fix(ci): fold OCI push into release job, push only changed charts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,17 @@ on:
     branches:
       - main
 
+concurrency:
+  # Cancel a superseded PR run when a new commit is pushed — skips a redundant
+  # kind install for the stale ref.
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-test:
     name: Lint and unit-test changed charts
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,21 @@ on:
     branches:
       - main
 
+permissions: {}
+
+concurrency:
+  # Serialize releases on the ref so two merges can't race the gh-pages index
+  # push or the OCI push. Don't cancel an in-flight release mid-publish.
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     permissions:
-        contents: write 
+      contents: write
     runs-on: ubuntu-latest
+    environment: dockerhub
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -21,30 +31,36 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_SKIP_EXISTING: true # https://github.com/helm/chart-releaser-action/issues/97
-  oci:
-    runs-on: ubuntu-latest
-    environment: 'dockerhub' 
-    steps:
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
           # renovate: datasource=github-releases depName=helm/helm
           version: v4.2.3
-        # id: install
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: true # https://github.com/helm/chart-releaser-action/issues/97
+          CR_GENERATE_RELEASE_NOTES: true
+
+      # chart-releaser leaves the charts it just released (changed versions only,
+      # deps vendored) in .cr-release-packages/. Push those same packages to OCI as
+      # a later step in this job so (a) OCI publishes only what Pages did, and (b) a
+      # failed release blocks the push — no channel desync. Mirrors the
+      # prometheus-community pattern.
       - name: Helm Registry Login
-        run: echo ${{ secrets.DOCKERHUB_TOKEN }} | helm registry login registry-1.docker.io --password-stdin -u ${{ secrets.DOCKERHUB_USERNAME }}
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Setup Task
-        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Helm Package Charts
-        run: for x in $(ls charts); do task pkg-with-dep APP=${x}; done
-      - name: Helm Push Charts
-        run: for x in $(ls *.tgz); do task oci-push FILE=${x}; done
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | helm registry login registry-1.docker.io --password-stdin -u "${{ secrets.DOCKERHUB_USERNAME }}"
+
+      - name: Push released charts to OCI
+        run: |
+          shopt -s nullglob
+          pkgs=(.cr-release-packages/*.tgz)
+          if [ ${#pkgs[@]} -eq 0 ]; then
+            echo "No newly released charts to push to OCI."
+            exit 0
+          fi
+          for pkg in "${pkgs[@]}"; do
+            echo "Pushing $pkg"
+            helm push "$pkg" oci://registry-1.docker.io/homeylabcharts
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,15 +169,17 @@ Two version fields in `Chart.yaml`, and they move differently:
 Pipeline:
 
 1. **Renovate** (CI) bumps `appVersion` when the upstream image releases, then bumps the chart `version` (upstream patch → chart patch; minor/major → chart minor), scoped so only the changed chart bumps. (The `helm-values` manager is disabled — image versions are tracked *only* via `appVersion`, never `values.yaml`.)
-2. On **merge to `main`**, [`release.yml`](.github/workflows/release.yml) runs:
-   - **`chart-releaser`** publishes any chart whose `Chart.yaml` `version` changed to the GitHub Pages Helm repo (`CR_SKIP_EXISTING` — unchanged versions are skipped).
-   - a second job packages **every** chart (with deps) and pushes it to the `homeylabcharts` OCI registry on Docker Hub.
+2. On **merge to `main`**, the single `release` job in [`release.yml`](.github/workflows/release.yml) runs:
+   - **`chart-releaser`** publishes any chart whose `Chart.yaml` `version` changed to the GitHub Pages Helm repo (`CR_SKIP_EXISTING` — unchanged versions are skipped), leaving the packaged `.tgz` (deps vendored) in `.cr-release-packages/`.
+   - a later step in the same job `helm push`es those same packages to the `homeylabcharts` OCI registry on Docker Hub — so OCI publishes **only** the charts Pages just did, and a failed release blocks the push (the two channels can't desync).
 
 **Consequence:** a templates-only change with an unchanged `version` ships **nothing** via chart-releaser. Always bump `version` when you want a release.
 
+**If the OCI push step fails after the release already published to Pages** (e.g. a Docker Hub auth/network blip), re-running the job won't republish it — `chart-releaser` now sees the version as already released and repackages nothing, leaving `.cr-release-packages/` empty. Recover manually for the affected chart: `task pkg-with-dep APP=<chart>` then `task oci-push FILE=<chart>-<version>.tgz`.
+
 ### Umbrella charts: release the subchart first
 
-Two charts bundle **first-party** subcharts from the OCI registry — `bookstack` (→ `bookstack-file-exporter`) and `exportarr` (→ `qbittorrent-exporter`, `tdarr-exporter`). At release, `release.yml` packages the parent by pulling those subcharts *from OCI*, but the job that pushes subcharts to OCI runs later in the same run. So bumping a subchart **and** the parent's dependency on it in one merge fails — the parent can't find the not-yet-published subchart version, and the **whole release aborts** (not just that chart).
+Two charts bundle **first-party** subcharts from the OCI registry — `bookstack` (→ `bookstack-file-exporter`) and `exportarr` (→ `qbittorrent-exporter`, `tdarr-exporter`). At release, `release.yml` packages the parent by pulling those subcharts *from OCI*, but the step that pushes subcharts to OCI runs later in the same job. So bumping a subchart **and** the parent's dependency on it in one merge fails — the parent can't find the not-yet-published subchart version, and the **whole release aborts** (not just that chart).
 
 **Rule:** ship the subchart bump in its own PR first (it lands in OCI + Pages), then bump the parent's `dependencies[].version` to match in a follow-up PR. `mariadb` is third-party and already published, so it needs no ordering.
 


### PR DESCRIPTION
## Changes

- **`release.yml`**: delete the standalone `oci` job; fold the OCI push into the `release` job as later steps that `helm push` the `.cr-release-packages/*.tgz` chart-releaser just built (deps vendored). A `nullglob` guard makes a no-change run a clean no-op.
- Docker Hub login step + `environment: dockerhub` move onto the `release` job (the `DOCKERHUB_*` secrets are environment-scoped, and `environment:` is job-level).
- Workflow hardening (both workflows): top-level `permissions: {}` on `release.yml`, `CR_GENERATE_RELEASE_NOTES: true`, `concurrency` groups (release: serialize on ref, no cancel mid-publish; ci: cancel superseded PR runs), `timeout-minutes` (release 15, ci 30).
- `CONTRIBUTING.md`: release section rewritten for the single-job flow + changed-only OCI push; added an OCI-push-failure recovery runbook; umbrella section "job" → "step".

## Motivation

The old `oci` job had two defects (HIGH finding in the fleet audit):

1. **No `needs: release`** — the Docker Hub push ran even when the Pages release failed, so the two publish channels could desync.
2. **`for x in $(ls charts)`** repackaged + re-pushed **every** chart on **every** merge (O(n); a bad umbrella pin could fail the whole loop, and every merge overwrote already-published OCI tags).

Folding the push into the release job publishes only what chart-releaser actually released (changed versions) and blocks the push when the release step fails — the prometheus-community pattern this repo already benchmarks against.

## Test plan

- `actionlint` (incl. shellcheck on the push loop) — clean.
- YAML parses for both workflows.
- **Merge-time verification** (cannot be exercised locally without pushing):
  - OCI push fires only for the chart(s) actually released.
  - GitHub Release carries generated notes.
  - `helm pull oci://registry-1.docker.io/homeylabcharts/bookstack` (an umbrella) still bundles its subcharts.

## In-depth

- **Accepted trade-off (self-heal gap):** if the OCI push step fails *after* chart-releaser already released to Pages, a re-run won't republish it — chart-releaser sees the version as released and repackages nothing, leaving `.cr-release-packages/` empty. This is the same gap prometheus-community lives with. Recovery is a documented manual `task pkg-with-dep` + `task oci-push` for the affected chart (added to CONTRIBUTING). Rejected the alternative (keep the separate job + a bespoke `helm show chart` skip-existing probe) as non-idiomatic maintenance surface with no upstream precedent.
- **`environment: dockerhub` now gates the whole `release` job**, chart-releaser included — not just the OCI push as before. No effect today (the environment has no protection rules; it only scopes the secrets), but a future required-reviewer/wait-timer rule would gate the Pages publish too. Escape hatch: move the Docker Hub secrets to repo-level and drop `environment:`.
- **Umbrella co-bump ordering is unchanged** — the parent still pulls subcharts from OCI during packaging, and the OCI push is still later in the run, so the "release the subchart first" two-PR rule in CONTRIBUTING still applies.