### PR TITLE
fix(ci): guard OCI login/push behind released-charts detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,22 +45,35 @@ jobs:
           CR_GENERATE_RELEASE_NOTES: true
 
       # chart-releaser leaves the charts it just released (changed versions only,
-      # deps vendored) in .cr-release-packages/. Push those same packages to OCI as
-      # a later step in this job so (a) OCI publishes only what Pages did, and (b) a
-      # failed release blocks the push — no channel desync. Mirrors the
-      # prometheus-community pattern.
-      - name: Helm Registry Login
-        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | helm registry login registry-1.docker.io --password-stdin -u "${{ secrets.DOCKERHUB_USERNAME }}"
-
-      - name: Push released charts to OCI
+      # deps vendored) in .cr-release-packages/. Push those same packages to OCI so
+      # (a) OCI publishes only what Pages did, and (b) a failed release blocks the
+      # push — no channel desync. Mirrors the prometheus-community pattern.
+      - name: Detect released charts
+        id: released
         run: |
           shopt -s nullglob
           pkgs=(.cr-release-packages/*.tgz)
-          if [ ${#pkgs[@]} -eq 0 ]; then
+          if [ ${#pkgs[@]} -gt 0 ]; then
+            echo "has=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has=false" >> "$GITHUB_OUTPUT"
             echo "No newly released charts to push to OCI."
-            exit 0
           fi
-          for pkg in "${pkgs[@]}"; do
+
+      # Log in / push only when there's something to publish, so doc- or
+      # workflow-only merges never touch Docker Hub.
+      - name: Helm Registry Login
+        if: steps.released.outputs.has == 'true'
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: echo "$DOCKERHUB_TOKEN" | helm registry login registry-1.docker.io -u "$DOCKERHUB_USERNAME" --password-stdin
+
+      - name: Push released charts to OCI
+        if: steps.released.outputs.has == 'true'
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*.tgz; do
             echo "Pushing $pkg"
             helm push "$pkg" oci://registry-1.docker.io/homeylabcharts
           done


### PR DESCRIPTION
## Changes

- Restructure the OCI publish in `release.yml` into three steps:
  - **Detect released charts** — sets `has=true/false` output based on whether chart-releaser left any `.cr-release-packages/*.tgz`.
  - **Helm Registry Login** and **Push released charts to OCI** — both gated on `has == 'true'`, so doc-/workflow-only merges never authenticate to Docker Hub.
- Credentials passed via `env:` (injection-safe) with plain quoted references — no runtime credential scrubbing.

## Motivation

The post-merge `release.yml` run for #153 failed at **Helm Registry Login** with `authenticating to "registry-1.docker.io": ... 400: Bad Request`.

Root cause: the `DOCKERHUB_USERNAME` environment secret carried a trailing newline (set via `echo` back in 2023). #153 changed the login flag from the old unquoted `-u ${{ secrets.DOCKERHUB_USERNAME }}` to quoted `-u "${{ ... }}"`; the quotes pulled the newline *inside* the value, malforming the credential. The prior unquoted form tolerated it only because the newline terminated the shell arg.

No publish was missed — the failing merge was workflow-only, nothing to push — but login ran (and failed) unconditionally, leaving `main` red and breaking the next real chart release.

**The secret has been re-saved without the newline**, so the root cause is fixed at source. This PR additionally makes the workflow only log in when it actually has charts to push.

## Test plan

- `actionlint` (incl. shellcheck) — clean.
- YAML parses.
- **Merge-time:** this workflow-only merge should pass green (detection → `has=false` → login/push skipped). A future chart bump exercises the real login+push path against the now-clean secret.

## In-depth

- An earlier revision of this PR trimmed whitespace from the secrets at runtime (`tr -d '[:space:]'`) as a defensive workaround. Dropped in favor of fixing the secret at source + gating login on package existence — no reason to scrub credentials the pipeline controls.