### PR TITLE
ci: validate CRD manifests against real schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ kube_config
 
 # Locally packaged charts (task pkg / pkg-with-dep)
 /*.tgz
+
+# Downloaded schemas (scripts/ci/kubeconform.sh)
+.cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ The [`Taskfile.yml`](Taskfile.yml) wraps every tool above behind one consistent,
 | Task | Runs |
 | --- | --- |
 | `task lint APP=<chart>` | `helm lint` |
-| `task kubeconform APP=<chart>` | `helm template … \| kubeconform -strict -ignore-missing-schemas` (k8s `1.30.0`, override with `K8S_VERSION=`) |
+| `task kubeconform APP=<chart>` | `scripts/ci/kubeconform.sh` — validates rendered manifests against k8s + CRD schemas (k8s `1.30.0`, override with `K8S_VERSION=`) |
 | `task unittest APP=<chart>` | `helm unittest` |
 | **`task verify APP=<chart>`** | **`lint` + `kubeconform` + `unittest` — the local mirror of the CI gate's cluster-free layers ([Continuous integration](#continuous-integration)).** Run before every commit. |
 | `task template APP=<chart>` | `helm template … --debug` (eyeball the rendered output) |
@@ -115,7 +115,7 @@ The chart has four independent test layers, cheapest and fastest first. Use the 
 | Layer | Tool / command | Needs a cluster? | What it proves |
 | --- | --- | --- | --- |
 | **Unit** | `task unittest APP=<chart>` (helm-unittest, `tests/*_test.yaml`) | No | Templates render the right output for given values — Secret keys, env wiring, conditionals, which manifests appear. Best place for `existingSecret`/edge-case paths. |
-| **Static** | `task lint` + `task kubeconform APP=<chart>` | No | Chart is well-formed and rendered manifests are schema-valid (CRDs skipped — see Gotchas). |
+| **Static** | `task lint` + `task kubeconform APP=<chart>` | No | Chart is well-formed and rendered manifests are schema-valid, CRD kinds included. Catches what unittest can't: wrong field names and wrong types. |
 | **Integration** | `task test APP=<chart>` (chart-testing `ct install`) | Yes (kind) | Chart *installs and becomes Ready* on a real cluster for each `ci/*-values.yaml` scenario — and the `helm test` hooks below run automatically at the end, unless the scenario disables them (see [`helm test`](#helm-test-connection-probes)). |
 | **Live behavior** | `task deploy-local APP=<chart>` → inspect → `task clean-local` | Yes (your context) | Runtime behavior the static layers can't catch — real backend connectivity, env-var semantics, probes under load — using your credentialed `.local/values/<chart>.yaml`. |
 
@@ -201,5 +201,6 @@ Two charts bundle **first-party** subcharts from the OCI registry — `bookstack
 - **`README.md` is generated — never hand-edit it.** Edit `README.md.gotmpl` and run `task docs APP=<chart>`. Value-table rows come from the `# --` comments in `values.yaml`.
 - **Chart `version` must bump or the release is silently skipped.** chart-releaser only publishes a chart whose `version` changed.
 - **`ci/*-values.yaml` must be self-contained.** `ct install` runs in a fresh namespace, so values referencing pre-existing cluster objects (`existingSecret`, an external PVC/secret) fail with `CreateContainerConfigError`. Test those paths with helm-unittest (cluster-free) instead. Keep memory limits generous for JVM/heavy images or `ct install` OOMs before Ready.
-- **`kubeconform` runs with `-ignore-missing-schemas`**, so CRD-based manifests (HTTPRoute, ServiceMonitor) are skipped, not validated. A green kubeconform does not prove those render correctly — cover them with `helm template` + unittest.
+- **Adding a CRD-backed feature? Add its toggle to `scripts/ci/kubeconform-values.yaml`.** These features all default to off, so that overlay is what makes them render for validation — miss it and nothing tests your manifest. Give it a real payload: a `prometheusRule` with an empty `rules` list renders `spec: null` and fails. The script fails loudly if a chart ships a CRD template that the overlay didn't reach, so you'll know.
+- **`kubeconform` deliberately runs *without* `-ignore-missing-schemas`.** A missing schema is a hard failure, not a silent skip. Schemas come from the network (kubeconform's default location plus the [datree CRDs-catalog](https://github.com/datreeio/CRDs-catalog)), so upstream breakage can red the gate with no local change. Cached under `.cache/` with no expiry — `rm -rf .cache/` if local disagrees with CI.
 - **Clean up local resources** — `task clean-local APP=<chart>` removes the `local-<chart>` namespace and release after `deploy-local`.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -55,7 +55,7 @@ tasks:
     requires:
       vars: [APP]
     cmds:
-      - ct install --chart-dirs {{.CHART_DIR}} --charts {{.CHART_DIR}}/{{.APP}}
+      - ct install --config .github/ct/ct.yaml --charts {{.CHART_DIR}}/{{.APP}}
 
   template:
     desc: Render a chart's templates (APP=<chart>)
@@ -65,11 +65,13 @@ tasks:
       - helm template {{.APP}} {{.CHART_DIR}}/{{.APP}} --debug
 
   kubeconform:
-    desc: Validate rendered manifests against k8s schemas (APP=<chart>)
+    desc: Validate rendered manifests against k8s + CRD schemas (APP=<chart>)
     requires:
       vars: [APP]
+    # Delegates to the same script CI runs (ct.yaml additional-commands) so the
+    # two cannot drift. Override the target version with K8S_VERSION=.
     cmds:
-      - helm template {{.APP}} {{.CHART_DIR}}/{{.APP}} | kubeconform -strict -summary -ignore-missing-schemas -kubernetes-version {{.K8S_VERSION | default "1.30.0"}}
+      - K8S_VERSION={{.K8S_VERSION | default "1.30.0"}} scripts/ci/kubeconform.sh {{.CHART_DIR}}/{{.APP}}
 
   unittest:
     desc: Run helm unittest for a chart (APP=<chart>)

--- a/scripts/ci/kubeconform-values.yaml
+++ b/scripts/ci/kubeconform-values.yaml
@@ -1,0 +1,70 @@
+# Values overlay for the kubeconform tier.
+#
+# Its only job is to force every CRD-backed feature ON so the rendered manifests
+# actually contain ServiceMonitor / PrometheusRule / HTTPRoute. With default
+# values all three are disabled, so the schema gate would validate nothing.
+#
+# Scope: the chart-authored structure of those manifests. Passthrough fields
+# that are pure user data (relabelings, extra labels/annotations, httproute
+# rules) are left empty on purpose — they carry no chart logic to regress, and
+# filling them would only validate this file.
+#
+# Lives OUTSIDE charts/ on purpose: it is not a `ci/*-values.yaml` scenario, so
+# `ct install` never installs it and kind needs no CRDs. It ships to nobody.
+#
+# Applied to every chart. Charts that don't define these keys ignore them
+# (no chart in this repo sets `additionalProperties: false`), so one file covers
+# the whole fleet.
+#
+# Payloads must stay REAL, not bare toggles: the PrometheusRule templates wrap
+# their body in `{{- with ...rules }}` under a bare `spec:`, so an empty list
+# renders `spec: null` and fails validation. Same for HTTPRoute parentRefs.
+
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+  prometheusRule:
+    enabled: true
+    rules:
+      - alert: TargetDown
+        expr: up == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Exporter target is down.
+
+httproute:
+  enabled: true
+  parentRefs:
+    - name: kubeconform-gateway
+      namespace: default
+      sectionName: websecure
+  hostnames:
+    - kubeconform.example.org
+
+# exportarr nests its own config one level down, and its ServiceMonitor is
+# emitted per enabled app — with every app disabled (the default) the chart
+# renders zero resources.
+exportarr:
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+    prometheusRule:
+      enabled: true
+      rules:
+        - alert: TargetDown
+          expr: up == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: Exporter target is down.
+  apps:
+    radarr:
+      - name: main
+        enabled: true
+        url: "http://radarr:7878"
+        apiKey: "0123456789abcdef0123456789abcdef"

--- a/scripts/ci/kubeconform.sh
+++ b/scripts/ci/kubeconform.sh
@@ -1,9 +1,47 @@
 #!/usr/bin/env bash
-# Render a chart and validate the manifests against Kubernetes schemas.
+# Render a chart and validate the manifests against Kubernetes + CRD schemas.
 # Usage: scripts/ci/kubeconform.sh <chart-dir>   (chart-dir e.g. charts/pihole-exporter)
 # Mirrors `task kubeconform`. Invoked per-chart by ct via ct.yaml additional-commands.
 set -euo pipefail
 
-chart="$1"
-helm template "$(basename "$chart")" "$chart" \
-  | kubeconform -strict -summary -ignore-missing-schemas -kubernetes-version 1.30.0
+chart="${1:?usage: kubeconform.sh <chart-dir>}"
+name="$(basename "$chart")"
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+k8s="${K8S_VERSION:-1.30.0}"
+cache="$root/.cache/kubeconform"
+
+# CRD schemas, via kubeconform's own documented catalog invocation. This and the
+# `default` location are both remote and unpinned — the gate has always needed
+# the network. Schemas cache with no expiry; `rm -rf .cache/` forces a refetch.
+catalog='https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+
+render() { helm template "$name" "$chart" --kube-version "$k8s" "$@"; }
+
+# No -ignore-missing-schemas: a 404 from a renamed catalog path or a typo'd kind
+# would read as a pass. (Outages were never silent — they error out either way.)
+validate() {
+  mkdir -p "$cache"
+  kubeconform -strict -summary -kubernetes-version "$k8s" -cache "$cache" \
+    -schema-location default -schema-location "$catalog"
+}
+
+# Pass 1 — default values, what users actually install.
+render | validate
+
+# Pass 2 — every CRD-backed feature forced on; nothing else renders the CRD kinds.
+crd_render="$(render --values "$root/scripts/ci/kubeconform-values.yaml")"
+
+# A renamed values key would make pass 2 render nothing and still report
+# `Skipped: 0`. Green on an empty document is the failure this gate exists to
+# catch, so check the CRD templates on disk against what actually came out.
+# Kinds are read from the templates, so only the filenames are listed here.
+for f in "$chart"/templates/{servicemonitor,prometheusrule,httproute}.yaml; do
+  [[ -f "$f" ]] || continue
+  kind="$(awk '/^kind: /{print $2; exit}' "$f")"
+  grep -q "^kind: ${kind}$" <<<"$crd_render" && continue
+  echo "ERROR: $name ships $(basename "$f") but the overlay rendered no ${kind}." >&2
+  echo "       Check its toggle in scripts/ci/kubeconform-values.yaml." >&2
+  exit 1
+done
+
+printf '%s\n' "$crd_render" | validate


### PR DESCRIPTION
## Changes

- Add `scripts/ci/kubeconform-values.yaml`, a single repo-level overlay that force-enables every CRD-backed feature (`ServiceMonitor`, `PrometheusRule`, `HTTPRoute`). All three default to disabled, so the schema gate previously had nothing to validate. It lives outside `charts/` deliberately: it is not a `ci/*-values.yaml` scenario, so `ct install` never installs it and the kind cluster needs no CRDs installed.
- Rewrite `scripts/ci/kubeconform.sh` to render each chart twice — default values, then with the overlay — and validate both against Kubernetes schemas plus CRD schemas from the datree CRDs-catalog.
- Fail if a chart ships `templates/{servicemonitor,prometheusrule,httproute}.yaml` but the overlay render emits none of that kind. Without this the gate cannot tell a passing render from an empty one: a renamed values key would report `Skipped: 0` on a manifest that never rendered, which is the exact failure being fixed here. Expectations come from the templates on disk, so they stay correct as charts are added or removed.
- Drop `-ignore-missing-schemas`. With a remote schema location a 404 (catalog rename, kind removal, typo'd kind) would read as a silent pass. Every chart reports `Skipped: 0` in both passes, so any skip is now a real regression. Network outages were never silent — they error and exit non-zero regardless.
- Honor `K8S_VERSION`, passing it to both `helm template --kube-version` and kubeconform. `Taskfile.yml` and `CONTRIBUTING.md` already documented the override while the script hardcoded `1.30.0`, so local and CI disagreed whenever it was set.
- Cache downloaded schemas under `.cache/` (gitignored); two passes across nine charts otherwise refetch on every pre-commit run.
- Point `task kubeconform` at the shared script so local and CI cannot drift, and pass `--config .github/ct/ct.yaml` to `task test`, which previously ran under different config than CI.

## Motivation

Three CRD kinds are rendered by these charts and validated by nothing. The manifests never render (features default off), their schemas were never loaded (`-ignore-missing-schemas`), and no install scenario enables them. Fixing any one alone changes nothing.

helm-unittest cannot close this gap: it asserts rendered output, so a suite asserting `interval == 30` passes green while the apiserver rejects the object with `expected string, got 30`.

For scale, `helm template exportarr charts/exportarr` with default values emits **zero resources** — every entry under `.Values.exportarr.apps` defaults to disabled. The static gate has been reporting green on an empty document for that chart.

## Test plan

CI cannot exercise this change (see In-depth), so the evidence is local:

- `task verify` green for all nine charts.
- `ct lint --config .github/ct/ct.yaml --charts charts/<chart>` runs both passes via `additional-commands`, `Skipped: 0` — checked for a leaf chart and for the umbrella.
- Negative controls, each failing with a precise message:
  - `rules` → `rulez` in a PrometheusRule template: `additional properties 'rulez' not allowed`, exit 1.
  - `serviceMonitor.interval: 30` unquoted: `at '/spec/endpoints/0/interval': got number, want string`.
  - `prometheusRule.rules: []`: `at '/spec': got null, want object`.
  - Chart-side rename of the `httproute` values key, so the overlay silently stops reaching it: the render guard fires with `ships templates/httproute.yaml but the overlay rendered no HTTPRoute`, exit 1. Reproduced for `nut-exporter` too, which has no unittest suite and so had nothing else covering it.
- `K8S_VERSION=1.31.0` passes; `K8S_VERSION=9.99.9` fails as expected.
- Cold cache (`rm -rf .cache/`) refetches and passes.

## In-depth

No chart is touched, so no version bump is required and chart-releaser publishes nothing.

**This PR's own CI run is vacuous.** Every step gates on `ct list-changed`, which only diffs within `chart-dirs: [charts]`, and nothing here lives there. Harmless in this case because acceptance is fully local, but it is a standing property of anything under `scripts/ci/` or `.github/ct/` — worth a follow-up that forces a run for those paths. Note that setting `changed=true` alone is insufficient: `ct lint` with no changed charts lints nothing, so it needs `--all` or an explicit chart list, which is a CI-cost decision of its own.

Both schema locations are remote and unpinned, so upstream breakage can red the gate with no local change. Pinning the catalog to a commit SHA is a follow-up if that ever bites — it trades a loud failure for a silent staleness, so it isn't obviously correct. The cache has no expiry, meaning a stale local cache can pass while cold CI fails; `rm -rf .cache/` is the reset and this is documented.

**Alternative considered and rejected:** seeding the CRDs into the kind cluster and enabling the features in each chart's `ci/*-values.yaml` (DataDog's file placement plus prometheus-community's seeding step). Its only coverage beyond this change is apiserver CEL `x-kubernetes-validations`; the cost is two pinned external versions, two network-fetching workflow steps, nine files instead of one, added `ct install` time, and a change verifiable only in CI. It also cannot cover `nut-exporter`, which has no `ci/` directory and is excluded from install. Available later as a strictly additive follow-up — nothing here blocks it.

**Precedent:** `DataDog/helm-charts` `.github/kubeconform.sh` is the closest analog — a wrapper script, a dedicated feature-enable values file, `-ignore-missing-schemas` deliberately absent, `--kube-version` on the render, and an explicit pointer to the datree catalog for CRD-backed kinds. The `-schema-location` template string is the canonical one from kubeconform's own README.

**Known follow-ups:** force a CI run for `scripts/ci/**` and `.github/ct/**` changes; pin the catalog if floating becomes disruptive; document `task update-dep` before verifying the two umbrella charts on a fresh clone (pre-existing — CI is unaffected, since `ct` builds dependencies before running `additional-commands`).
