### PR TITLE
ci: cover every off-by-default template in the kubeconform overlay

### DIFF
--- a/scripts/ci/kubeconform-values.yaml
+++ b/scripts/ci/kubeconform-values.yaml
@@ -1,13 +1,10 @@
 # Values overlay for the kubeconform tier.
 #
-# Its only job is to force every CRD-backed feature ON so the rendered manifests
-# actually contain ServiceMonitor / PrometheusRule / HTTPRoute. With default
-# values all three are disabled, so the schema gate would validate nothing.
-#
-# Scope: the chart-authored structure of those manifests. Passthrough fields
-# that are pure user data (relabelings, extra labels/annotations, httproute
-# rules) are left empty on purpose — they carry no chart logic to regress, and
-# filling them would only validate this file.
+# Its job is to force every off-by-default feature ON so the rendered manifests
+# actually contain the templates the gate is supposed to check. With default
+# values the CRD kinds (ServiceMonitor / PrometheusRule / HTTPRoute) and a dozen
+# core-kind templates never render at all, so the schema gate would validate
+# nothing for them.
 #
 # Lives OUTSIDE charts/ on purpose: it is not a `ci/*-values.yaml` scenario, so
 # `ct install` never installs it and kind needs no CRDs. It ships to nobody.
@@ -16,14 +13,37 @@
 # (no chart in this repo sets `additionalProperties: false`), so one file covers
 # the whole fleet.
 #
-# Payloads must stay REAL, not bare toggles: the PrometheusRule templates wrap
-# their body in `{{- with ...rules }}` under a bare `spec:`, so an empty list
-# renders `spec: null` and fails validation. Same for HTTPRoute parentRefs.
+# Two rules for anything added here, both learned the hard way:
+#
+#   1. Payloads must be REAL, not bare toggles. The PrometheusRule templates
+#      wrap their body in `{{- with ...rules }}` under a bare `spec:`, so an
+#      empty list renders `spec: null` and fails validation. Same for HTTPRoute
+#      parentRefs.
+#
+#   2. Give every list and map at least TWO entries. Passthrough fields render
+#      via `toYaml | nindent N` inside conditionals — leaving them empty takes
+#      the `{{- else }}` branch and never exercises the indentation logic, which
+#      is where `range`/`nindent` bugs actually live. Same reasoning as Apache
+#      Pulsar's `.ci/templates-all-values.yaml`.
+#
+# New off-by-default feature ⇒ add its toggle here, or the gate never sees it.
 
 metrics:
   enabled: true
   serviceMonitor:
     enabled: true
+    relabelings:
+      - sourceLabels: [__meta_kubernetes_pod_node_name]
+        targetLabel: node
+      - sourceLabels: [__meta_kubernetes_namespace]
+        targetLabel: ns
+    metricRelabelings:
+      - sourceLabels: [__name__]
+        regex: go_.*
+        action: drop
+      - sourceLabels: [__name__]
+        regex: promhttp_.*
+        action: drop
   prometheusRule:
     enabled: true
     rules:
@@ -37,6 +57,26 @@ metrics:
 
 httproute:
   enabled: true
+  annotations:
+    kubeconform.example.org/first: "1"
+    kubeconform.example.org/second: "2"
+  # Non-empty so the `{{- if .Values.httproute.rules }}` branch renders instead
+  # of the default-backendRef fallback.
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /metrics
+      backendRefs:
+        - name: kubeconform-backend
+          port: 9090
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: kubeconform-backend
+          port: 9090
   parentRefs:
     - name: kubeconform-gateway
       namespace: default
@@ -44,14 +84,47 @@ httproute:
   hostnames:
     - kubeconform.example.org
 
-# exportarr nests its own config one level down, and its ServiceMonitor is
-# emitted per enabled app — with every app disabled (the default) the chart
-# renders zero resources.
+# Core kinds that no default render reaches. Uniform key names across the fleet,
+# so one block covers every chart that ships the template.
+serviceAccount:
+  create: true
+
+ingress:
+  enabled: true
+
+# nut-exporter only. It is also the one chart `ct install` never touches
+# (excluded in .github/workflows/ci.yml), so this overlay is its only coverage.
+webconfig_file: |
+  tls_server_config:
+    cert_file: /etc/nut-exporter/tls.crt
+    key_file: /etc/nut-exporter/tls.key
+
+# v-rising ships a second Service for RCON, off by default and not enabled by
+# its ci/ scenario.
+service:
+  rcon:
+    enabled: true
+
+# exportarr nests its own config one level down, so every block above needs a
+# copy here. Its ServiceMonitor is emitted per enabled app — with every app
+# disabled (the default) the chart renders zero resources.
 exportarr:
   metrics:
     enabled: true
     serviceMonitor:
       enabled: true
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: node
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: ns
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: go_.*
+          action: drop
+        - sourceLabels: [__name__]
+          regex: promhttp_.*
+          action: drop
     prometheusRule:
       enabled: true
       rules:
@@ -62,6 +135,8 @@ exportarr:
             severity: warning
           annotations:
             summary: Exporter target is down.
+  serviceAccount:
+    create: true
   apps:
     radarr:
       - name: main


### PR DESCRIPTION
Follow-up to #166, which added the two-pass kubeconform gate and this overlay. Single file changed: `scripts/ci/kubeconform-values.yaml`.

## Changes

**Coverage — 11 templates that rendered in no pass at all.** The overlay only forced the CRD-backed features on. Everything else off-by-default was invisible to the gate:

| kind | charts | toggle added |
| --- | --- | --- |
| `ServiceAccount` | bookstack, exportarr, nut-exporter, pihole, qbittorrent, tdarr, v-rising | `serviceAccount.create` (+ the `exportarr:`-nested copy) |
| `Ingress` | bookstack, unpoller | `ingress.enabled` |
| `ConfigMap` | nut-exporter (`webconfig.yaml`) | `webconfig_file` |
| `Service` | v-rising (`rcon-service.yaml`) | `service.rcon.enabled` |

Neither ingress chart needs a host payload — both ship real default `hosts` with `pathType`.

**Passthrough fields now carry real payloads.** The file previously left them empty on the stated theory that they carry no chart logic. They do:

```
charts/*/templates/httproute.yaml:21-28
  rules:
  {{- if .Values.httproute.rules }}
    {{- toYaml .Values.httproute.rules | nindent 4 }}   <- never reached
  {{- else }}
    - backendRefs: ...                                  <- what was validated
```

An empty `rules` list took the fallback branch, so the `toYaml | nindent 4` path never ran in any of the 5 charts shipping the template. Same for `httproute.annotations` (a `{{- with }}` block that never opened) and for `serviceMonitor.relabelings` / `metricRelabelings`. Every list and map now carries at least two entries so the nested indentation is actually exercised.

Header comment rewritten to state both rules (real payloads; >= 2 entries) and to drop the empty-passthrough rationale.

## Motivation

#166 proved the gate can catch CRD type errors, but it only pointed the gate at CRD kinds. The rest of each chart's optional surface was still unvalidated, and the passthrough conditionals — where `range`/`nindent` bugs actually live — were structurally unreachable.

## What is deliberately NOT here

- **The remaining unrendered templates** (`Secret` x4, bfe's `Deployment`/`PVC`/`Secret`) are covered by `ct install` on kind, which applies them to a real apiserver — strictly stronger than kubeconform for core kinds. Chasing them statically buys nothing.
- **A patch overlay for mutually exclusive branches** (Pulsar's `templates-all-values-patch1.yaml`). Those are the `{{- if not .Values.*existing* }}` / `{{- else }}` pairs, and helm-unittest already covers them in 8 of 9 charts; only nut-exporter lacks it, and nut-exporter has no `tests/` directory at all. Pulsar needs the second file because they have no unit-test tier.
- **Rendering `ci/*-values.yaml` in the static tier.** Measured: adds zero coverage over `ct install`, and would give those files a second, conflicting purpose.
- **Generalizing #166's guard** to drop its hardcoded filename list. The obvious form is unsound — it matches on kind, so `v-rising/templates/rcon-service.yaml` would pass on the strength of `service.yaml`'s `Service`, and a subchart's manifest can satisfy a parent template. If revisited it must match on the `# Source:` path instead.

## Verification

- `task verify` on all 9 charts: green. Both passes `Skipped: 0`, unittest suites unchanged (26/45/23/0/31/35/32/43/36).
- Per-template coverage scan (matched on `# Source:` path, not kind): **21 -> 0** templates unreachable by any pass or `ct install` scenario.
- Previously-dead branches confirmed rendering: `httproute.rules` (2 entries), `httproute.annotations`, `relabelings` in both the top-level and `exportarr:`-nested copies.
- Negative controls on the newly-covered `Ingress`, all previously invisible:
  - `pathType: Prefix` -> `3` => `at '/spec/rules/0/http/paths/0/pathType': got number, want string`
  - `port.number` -> `"8080"` => `got string, want null or integer`
  - `service:` -> `servce:` => `additional properties 'servce' not allowed`

## In-depth

**No chart is touched**, so no version bump and no release — consistent with #166.

**This PR's own CI is vacuous.** `scripts/` sits outside `chart-dirs`, so `ct list-changed` returns nothing and neither lint nor kubeconform runs on it. Verification above is local. Making CI run the static tier when the tier itself changes is a known follow-up; it needs a cost decision, since `ct lint` with no changed charts lints nothing and would need `--all` or an explicit list.

**On the `exportarr` umbrella:** it ships no `httproute.yaml` of its own, so the top-level `httproute:` block not reaching subchart values is expected. `qbittorrent-exporter` and `tdarr-exporter` are validated as their own charts.

**Prior art:** the "one dedicated values file that force-enables everything" shape follows Apache Pulsar's `.ci/templates-all-values.yaml`, which uses the same `-strict` + datree CRDs-catalog invocation and documents the same >= 2-entries rule. DataDog's per-chart `charts/<chart>/ci/kubeconform-values.yaml` was considered and rejected: anything matching `*-values.yaml` under a chart's `ci/` gets installed by `ct install`, which would require seeding CRDs into kind.