### PR TITLE
ci: validate the static tier when the tier itself changes

### DIFF
--- a/.github/workflows/ci-tooling.yml
+++ b/.github/workflows/ci-tooling.yml
@@ -1,0 +1,75 @@
+name: CI tooling
+permissions: {}
+
+# The static validation tier lives outside `chart-dirs: [charts]`, so `ct list-changed`
+# returns nothing for a PR that only edits it and every step in ci.yml skips. `ct lint`
+# is no help either — with no changed charts it prints "All charts linted successfully"
+# and exits 0 on zero work. A typo in kubeconform.sh would merge green.
+#
+# So: run the tier against the whole fleet whenever the tier itself changes. Path filters
+# are workflow-level in Actions, which is why this is a separate file rather than a job
+# in ci.yml. No ct and no kind here — this tier is cluster-free and takes seconds.
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - scripts/ci/**
+      - .github/ct/**
+      - .github/workflows/ci-tooling.yml
+
+concurrency:
+  group: ci-tooling-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  static-tier:
+    name: Validate the static tier against every chart
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          # renovate: datasource=github-releases depName=helm/helm
+          version: v4.2.3
+
+      - name: Install helm-unittest plugin
+        env:
+          # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
+          UNITTEST_VERSION: v1.1.1
+        # Helm 4 verifies plugin sources by default; unsigned git installs need --verify=false
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version "${UNITTEST_VERSION#v}" --verify=false
+
+      - name: Install kubeconform
+        env:
+          # renovate: datasource=github-releases depName=yannh/kubeconform
+          KUBECONFORM_VERSION: v0.8.0
+        run: |
+          curl -fsSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin kubeconform
+
+      # Both commands ct runs via `additional-commands`, over every chart including the two
+      # ct.yaml excludes from install. Chart.lock is gitignored, so umbrellas need
+      # `dependency update` (build has no lock to read).
+      - name: Run unittest + kubeconform on every chart
+        run: |
+          fail=0
+          for chart in charts/*/; do
+            name="$(basename "$chart")"
+            echo "::group::${name}"
+            if grep -q '^dependencies:' "${chart}Chart.yaml"; then
+              helm dependency update "$chart" || { fail=1; echo "::endgroup::"; continue; }
+            fi
+            helm unittest "$chart" || fail=1
+            bash scripts/ci/kubeconform.sh "$chart" || fail=1
+            echo "::endgroup::"
+          done
+          exit "$fail"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,12 @@ helm test <release> -n <namespace>
 
 The **`Lint and unit-test changed charts`** check is required via branch protection — a red gate blocks merge.
 
+### When the tooling itself changes
+
+`ct` only ever looks under `chart-dirs: [charts]`, so a PR that edits the validation tier — `scripts/ci/**` or `.github/ct/**` — changes no chart, and every step above skips. `ct lint` is no safety net either: with nothing changed it prints `All charts linted successfully` and exits 0 on zero work.
+
+[`ci-tooling.yml`](.github/workflows/ci-tooling.yml) covers that case. It triggers on those paths only, and runs `helm unittest` + `scripts/ci/kubeconform.sh` against **every** chart — no `ct`, no kind, a handful of seconds. Editing the gate proves the gate still works fleet-wide.
+
 ### What counts as "changed" (`use-helmignore`)
 
 `ct.yaml` sets `use-helmignore: true`, and each active chart's `.helmignore` excludes `/ci/` and `/tests/` (`nut-exporter` is deprecated and has neither directory). Those paths are test scaffolding: they are run *from the repo* and are not shipped to chart consumers. Two consequences:
@@ -201,6 +207,6 @@ Two charts bundle **first-party** subcharts from the OCI registry — `bookstack
 - **`README.md` is generated — never hand-edit it.** Edit `README.md.gotmpl` and run `task docs APP=<chart>`. Value-table rows come from the `# --` comments in `values.yaml`.
 - **Chart `version` must bump or the release is silently skipped.** chart-releaser only publishes a chart whose `version` changed.
 - **`ci/*-values.yaml` must be self-contained.** `ct install` runs in a fresh namespace, so values referencing pre-existing cluster objects (`existingSecret`, an external PVC/secret) fail with `CreateContainerConfigError`. Test those paths with helm-unittest (cluster-free) instead. Keep memory limits generous for JVM/heavy images or `ct install` OOMs before Ready.
-- **Adding a CRD-backed feature? Add its toggle to `scripts/ci/kubeconform-values.yaml`.** These features all default to off, so that overlay is what makes them render for validation — miss it and nothing tests your manifest. Give it a real payload: a `prometheusRule` with an empty `rules` list renders `spec: null` and fails. The script fails loudly if a chart ships a CRD template that the overlay didn't reach, so you'll know.
+- **Adding an off-by-default feature? Add its toggle to `scripts/ci/kubeconform-values.yaml`.** Anything gated behind an `enabled`/`create` flag — the CRD kinds, but also `serviceAccount.create`, `ingress.enabled` and friends — renders in no default pass, so that overlay is what makes it render for validation. Miss it and nothing tests your manifest. Two rules: give it a **real payload** (a `prometheusRule` with an empty `rules` list renders `spec: null` and fails), and give every list and map **at least two entries** (an empty passthrough takes the `{{- else }}` branch and never exercises the `toYaml | nindent` path, which is where indent bugs live). The script fails loudly if a chart ships a CRD template the overlay didn't reach — but that guard matches on *kind*, so it does not extend to core kinds.
 - **`kubeconform` deliberately runs *without* `-ignore-missing-schemas`.** A missing schema is a hard failure, not a silent skip. Schemas come from the network (kubeconform's default location plus the [datree CRDs-catalog](https://github.com/datreeio/CRDs-catalog)), so upstream breakage can red the gate with no local change. Cached under `.cache/` with no expiry — `rm -rf .cache/` if local disagrees with CI.
 - **Clean up local resources** — `task clean-local APP=<chart>` removes the `local-<chart>` namespace and release after `deploy-local`.

--- a/scripts/ci/kubeconform-values.yaml
+++ b/scripts/ci/kubeconform-values.yaml
@@ -26,6 +26,15 @@
 #      is where `range`/`nindent` bugs actually live. Same reasoning as Apache
 #      Pulsar's `.ci/templates-all-values.yaml`.
 #
+# Rule 2 trades rather than adds where the two branches are mutually exclusive:
+# filling `httproute.rules` renders the `toYaml | nindent` branch *instead of*
+# the default-backendRefs `{{- else }}` fallback, and pass 1 has httproute off,
+# so that fallback is now schema-validated nowhere. Accepted: all 5 charts
+# shipping the template cover it in `tests/httproute_test.yaml` ("generates a
+# default backendRef rule..."). Coverage here is per-template, not per-branch —
+# Pulsar's second `-patch1.yaml` overlay is what closes that, and it is not
+# worth a second render pass while the unit-test tier holds.
+#
 # New off-by-default feature ⇒ add its toggle here, or the gate never sees it.
 
 metrics:

--- a/scripts/ci/kubeconform.sh
+++ b/scripts/ci/kubeconform.sh
@@ -28,7 +28,8 @@ validate() {
 # Pass 1 — default values, what users actually install.
 render | validate
 
-# Pass 2 — every CRD-backed feature forced on; nothing else renders the CRD kinds.
+# Pass 2 — every off-by-default feature forced on. Without it the CRD kinds and a
+# dozen core-kind templates (ServiceAccount, Ingress, …) render in no pass at all.
 crd_render="$(render --values "$root/scripts/ci/kubeconform-values.yaml")"
 
 # A renamed values key would make pass 2 render nothing and still report


### PR DESCRIPTION
Follow-up to #166 and #167. Closes the gap both of them merged through.

## Changes

**New workflow `.github/workflows/ci-tooling.yml`.** Triggers on `scripts/ci/**`, `.github/ct/**`, and its own path. Runs the two commands `ct.yaml` wires as `additional-commands` — `helm unittest` and `scripts/ci/kubeconform.sh` — against every chart. No `ct`, no kind.

Separate file rather than a job in `ci.yml` because path filters are workflow-level in Actions; a per-job filter would need `dorny/paths-filter` or a bespoke `git diff` step, neither of which earns its keep for one job.

**Two comment fixes carried over from the #167 review**, which merged without them:

- `scripts/ci/kubeconform.sh:31` still described pass 2 as "every CRD-backed feature forced on". It stopped being CRD-only when the overlay grew `serviceAccount.create`, `ingress.enabled`, nut's `webconfig_file` and v-rising's `service.rcon.enabled`.
- The overlay header now records what its ">= 2 entries" rule costs. Filling a passthrough renders the `toYaml | nindent` branch *instead of* the `{{- else }}` fallback, and pass 1 has the feature off, so that fallback is no longer schema-validated anywhere. Accepted — all five charts shipping `httproute.yaml` cover it in `tests/httproute_test.yaml` — but coverage here is per-template, not per-branch, and that should not need rediscovering.

**`CONTRIBUTING.md`** gains a "When the tooling itself changes" subsection, and the overlay gotcha is corrected from "CRD-backed feature" to off-by-default, with the >= 2-entries rule and the guard's kind-matching limit spelled out.

## Motivation

`ct` only looks under `chart-dirs: [charts]`. A PR that edits the validation tier changes no chart, so `ct list-changed` returns nothing and every step in `ci.yml` skips on its `changed == 'true'` condition.

`ct lint` is not a backstop. With nothing changed it exits 0 and prints:

```
Linting charts...
No chart changes detected.
All charts linted successfully
```

Green on zero work. #166 and #167 both merged on that; a typo in `kubeconform.sh` would have merged the same way.

Surveyed prometheus-community, grafana and DataDog first. All three gate only the kind/install tier on `list-changed` and run `ct lint` unconditionally — but that does not help here, because `ct lint` does its own changed-detection internally and no-ops regardless. None of the three validates its own CI tooling. DataDog comes closest by policy: a workflow-level `paths:` filter restricted to chart files plus a `changed` job that hard-fails any PR touching no chart.

## Verification

- Full loop green on all 9 charts, **23.5s** including `dependency update` for both umbrellas.
- Negative control — renamed `httproute:` to `httprout:` in the overlay: 5 charts fail, loop exits 1.
- Negative control — `-strict` to `-strickt` in `kubeconform.sh`: all 9 fail, loop exits 1.
- Both mutations reverted and the diff confirmed clean before committing.
- Workflow YAML parses. `actionlint` was not available locally, so that check is unrun.
- This PR exercises the new workflow on itself: `.github/workflows/ci-tooling.yml` is in its own trigger list, and `scripts/ci/**` is touched regardless. First real proof is the PR run.

## In-depth

**No chart is touched**, so no version bump and no release — same as #166 and #167.

**Umbrellas need their subcharts vendored before `helm template` will render them.** `Chart.lock` is gitignored, so a fresh checkout has none and `dependency update` and `dependency build` behave identically — `build` documents the fallback and mirrors `update` when no lock is found. `update` is used because it names what actually happens. Re-negotiation is a no-op: both deps are pinned to exact versions, not ranges, and a regenerated lock differs from the original only in its `generated:` timestamp.

**Consequence: the two umbrellas are pulled from the OCI registry on every run.** Not new — `ct` already vendors deps before `additional-commands`, so `ci.yml` has done this since OCI publishing landed, and on a much hotter trigger. Worth revisiting together (commit `Chart.lock`, cache `charts/*/charts` keyed on its hash, switch both to `dependency build`) if Docker Hub anonymous pull limits ever surface as flakes. Deliberately out of scope here.

**Known limit:** this covers the tier's *inputs*, not `ci.yml` itself. A change to `ci.yml` or `release.yml` still has no gate.