### PR TITLE
ci: lint the workflow files

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,42 @@
+name: actionlint
+permissions: {}
+
+# ci.yml and release.yml gate the charts; nothing gated them. A typo'd `uses:`, an
+# undefined context property or a bad `if:` expression merges silently and surfaces
+# when a release fails. actionlint type-checks all of that statically.
+#
+# Runs on every PR rather than filtering on `.github/workflows/**`. It costs seconds,
+# and a path-filtered check can never be required by branch protection: PRs that miss
+# the filter never report it, so the merge blocks forever on a status that will not
+# arrive. No filter means it always reports.
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: actionlint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: Lint workflow files
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Digest-pinned image, not the `bash <(curl .../download-actionlint.bash)` form the
+      # upstream docs lead with, and not a curl'd release tarball: both fetch by tag with
+      # no content verification, and this repo SHA-pins every action precisely to avoid
+      # that. The image also carries its own shellcheck, so `run:` blocks are linted with
+      # a pinned version rather than whatever the runner image happens to ship.
+      - name: Run actionlint
+        uses: docker://docker.io/rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+        with:
+          args: -color

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ Install these tools (a [`.devcontainer`](.devcontainer/) is provided that builds
 | [kubeconform](https://github.com/yannh/kubeconform) | validate rendered manifests | `kubeconform` |
 | [chart-testing](https://github.com/helm/chart-testing) (`ct`) | install charts on a real cluster | `ct` |
 | [kind](https://kind.sigs.k8s.io/) + `kubectl` | local cluster for `ct` / `deploy-local` | `kind`, `kubectl` |
+| [actionlint](https://github.com/rhysd/actionlint) (+ [shellcheck](https://www.shellcheck.net/)) | lint the GitHub Actions workflows | `actionlint`, `shellcheck` |
 
 All task commands take the target chart via `APP=<chart>`, e.g. `task verify APP=bookstack`. Run `task` (or `task --list`) to see every target.
 
@@ -44,6 +45,7 @@ The [`Taskfile.yml`](Taskfile.yml) wraps every tool above behind one consistent,
 | **`task verify APP=<chart>`** | **`lint` + `kubeconform` + `unittest` — the local mirror of the CI gate's cluster-free layers ([Continuous integration](#continuous-integration)).** Run before every commit. |
 | `task template APP=<chart>` | `helm template … --debug` (eyeball the rendered output) |
 | `task docs APP=<chart>` | regenerate `README.md` via helm-docs |
+| `task actionlint` | `actionlint` over `.github/workflows/` — repo-wide, no `APP=`. Only needed when you touch a workflow. |
 
 ### Local cluster (needs a running cluster / current kube-context)
 
@@ -166,6 +168,10 @@ The **`Lint and unit-test changed charts`** check is required via branch protect
 `ct` only ever looks under `chart-dirs: [charts]`, so a PR that edits the validation tier — `scripts/ci/**` or `.github/ct/**` — changes no chart, and every step above skips. `ct lint` is no safety net either: with nothing changed it prints `All charts linted successfully` and exits 0 on zero work.
 
 [`ci-tooling.yml`](.github/workflows/ci-tooling.yml) covers that case. It triggers on those paths only, and runs `helm unittest` + `scripts/ci/kubeconform.sh` against **every** chart — no `ct`, no kind, a handful of seconds. Editing the gate proves the gate still works fleet-wide.
+
+The workflows themselves are the other half: nothing validated *them*, so a typo'd `uses:`, an undefined context property or a bad `if:` expression would merge silently and surface when a release failed. [`actionlint.yml`](.github/workflows/actionlint.yml) type-checks the lot. It runs on **every** PR rather than filtering on `.github/workflows/**`: it costs seconds, and a path-filtered check can never be required by branch protection — PRs that miss the filter never report it, so the merge blocks forever waiting on a status that will never arrive.
+
+Mirrored locally by `task actionlint`. Install `shellcheck` alongside actionlint: it gets picked up automatically to lint `run:` blocks, and CI's pinned image bundles it, so without it locally you get a weaker check than the gate.
 
 ### What counts as "changed" (`use-helmignore`)
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -50,6 +50,14 @@ tasks:
     cmds:
       - helm lint {{.CHART_DIR}}/{{.APP}}
 
+  actionlint:
+    desc: Lint the GitHub Actions workflows (repo-wide, no APP)
+    # Mirrors .github/workflows/actionlint.yml. Install shellcheck too — actionlint
+    # picks it up automatically and lints `run:` blocks; CI's pinned image bundles
+    # it, so without it locally you get a weaker check than the gate.
+    cmds:
+      - actionlint -color
+
   test:
     desc: Run chart-testing install for a chart (APP=<chart>)
     requires:


### PR DESCRIPTION
Companion to #169. That PR gated the static tier's *inputs* (`scripts/ci/**`, `.github/ct/**`); this one gates the workflow files themselves.

## Changes

**New workflow `.github/workflows/actionlint.yml`.** Runs `actionlint` over `.github/workflows/` on every PR.

**`task actionlint`** mirrors it locally, and `CONTRIBUTING.md` gains the tool, the task, and a paragraph in "When the tooling itself changes".

## Motivation

Nothing validates `ci.yml`, `release.yml` or `ci-tooling.yml`. A typo'd `uses:`, an undefined context property or a malformed `if:` expression merges silently and surfaces when a release fails.

## Two choices worth explaining

**Digest-pinned image, not a curl'd binary.** Upstream docs lead with `bash <(curl .../download-actionlint.bash)`; the next most common form is a curl'd release tarball. Both fetch by tag over HTTPS with no content verification, which is exactly what this repo SHA-pins every action to avoid. `docker://docker.io/rhysd/actionlint:1.7.12@sha256:b1934ee…` is content-addressed. The image also carries its own shellcheck, so `run:` blocks are linted against a pinned version rather than whatever the runner image happens to ship.

Verified rather than assumed — the docs do not state whether Renovate handles `docker://image:tag@sha256:` refs, so Renovate's extractor was run against this repo:

```
"depName": "docker.io/rhysd/actionlint",
"replaceString": "docker.io/rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667",
"datasource": "docker",  "depType": "docker"
"packageFile": ".github/workflows/actionlint.yml"
```

Tag and digest both sit inside `replaceString`, so a bump carries both.

**No `paths:` filter.** It costs seconds, and a path-filtered check can never be required by branch protection: a PR that misses the filter never reports the check, so the merge blocks forever waiting on a status that will never arrive. Unfiltered, it always reports and stays eligible to be required.

## Prior art

Surveyed the four established install forms by GitHub code search (`path:.github/workflows`): download script 2008, `reviewdog/action-actionlint` 1688, curl'd release tarball 1256, `docker://` 880. No dominant convention.

Among helm chart repos — prometheus-community, grafana, bitnami, DataDog, helm/charts, helm/chart-testing — **zero** use actionlint, the same "nobody lints their own CI" pattern #169 found. grafana runs `super-linter` v3.12.0 with most validators disabled, which is not equivalent.

`cilium/cilium` is the closest posture match (SHA-pins everything, monorepo) and pins `docker://docker.io/rhysd/actionlint:1.7.12@sha256:b1934ee…` — the identical digest — with no path filter. This follows that.

## Verification

actionlint 1.7.12 with shellcheck 0.11.0 on the current tree: **clean, exit 0** across all four workflows.

Negative controls, each injected then reverted:

- `github.workflow` -> `github.workfloww` => `property "workfloww" is not defined in object type {...}` `[expression]`
- `name="$(basename "$chart")"` -> `name=$(basename $chart)` => `shellcheck reported issue in this script: SC2086:info:3:19: Double quote to prevent globbing and word splitting` `[shellcheck]`
- `uses:` -> `usess:` => `step must run script with "run" section or run action with "uses" section` `[syntax-check]`

Exit code confirmed separately: `1` on a bad file, `0` on a clean one. Image digest resolved from the registry and matches the pin. `task --list` shows the new target.

This PR triggers the workflow on itself, so the PR run is the real proof.

## In-depth

**No chart is touched**, so no version bump and no release.

**It finds nothing today.** All four workflows are already clean — insurance against a class of error that stays invisible until it fires in `release.yml`, not a fix for a present bug.

**Not yet required by branch protection.** Dropping the path filter makes it eligible; adding it to the required contexts is a separate repo-settings change.

**Optional follow-ups not taken:** actionlint's problem matcher (`.github/actionlint-matcher.json`) for inline PR annotations, which cilium uses — it means vendoring and maintaining a JSON file. And cilium lints for `ubuntu-latest` as a floating runner tag; all four workflows here use it, which is the same class of reasoning as SHA-pinning but a broader change than this PR.