### PR TITLE
test: cover ingress.yaml fleet-wide, and gate unit-test suites in CI

### DIFF
--- a/.github/workflows/ci-tooling.yml
+++ b/.github/workflows/ci-tooling.yml
@@ -6,9 +6,15 @@ permissions: {}
 # is no help either — with no changed charts it prints "All charts linted successfully"
 # and exits 0 on zero work. A typo in kubeconform.sh would merge green.
 #
-# So: run the tier against the whole fleet whenever the tier itself changes. Path filters
-# are workflow-level in Actions, which is why this is a separate file rather than a job
-# in ci.yml. No ct and no kind here — this tier is cluster-free and takes seconds.
+# So: run the tier against the whole fleet whenever the tier changes, or when one of the
+# chart-side inputs `ct` cannot see changes — the helmignored ci/ overlays and tests/
+# suites below. Chart PRs usually touch templates/ and tests/ together, so this now fires
+# alongside ci.yml on most of them; that is fine, it is cluster-free and takes seconds.
+# Path filters are workflow-level in Actions, which is why this is a separate file rather
+# than a job in ci.yml.
+#
+# Not a required status check: a path-filtered check never reports on PRs that miss the
+# filter, so branch protection would block forever waiting on it.
 on:
   pull_request:
     branches:

--- a/.github/workflows/ci-tooling.yml
+++ b/.github/workflows/ci-tooling.yml
@@ -19,6 +19,10 @@ on:
       # ci/ dir, so `ct list-changed` never sees them and ci.yml skips - this
       # workflow is their only gate.
       - charts/*/ci/kubeconform-overlay.yaml
+      # helm-unittest suites, for the same reason: `/tests/` is helmignored in
+      # every chart, so a PR that only adds or edits a suite drops the chart out
+      # of `ct list-changed` and the new tests would run nowhere.
+      - charts/*/tests/**
       - .github/ct/**
       - .github/workflows/ci-tooling.yml
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,9 +165,11 @@ The **`Lint and unit-test changed charts`** check is required via branch protect
 
 ### When the tooling itself changes
 
-`ct` only ever looks under `chart-dirs: [charts]`, so a PR that edits the validation tier — `scripts/ci/**` or `.github/ct/**` — changes no chart, and every step above skips. `ct lint` is no safety net either: with nothing changed it prints `All charts linted successfully` and exits 0 on zero work.
+`ct` only ever looks under `chart-dirs: [charts]`, so a PR that edits the validation tier — `scripts/ci/**` or `.github/ct/**` — changes no chart, and every step above skips. `ct lint` is no safety net either: with nothing changed it prints `All charts linted successfully` and exits 0 on zero work. The same hole swallows the chart-side inputs `ct` cannot see, because they are helmignored: `charts/*/ci/kubeconform-overlay.yaml` and `charts/*/tests/**`.
 
-[`ci-tooling.yml`](.github/workflows/ci-tooling.yml) covers that case. It triggers on those paths only, and runs `helm unittest` + `scripts/ci/kubeconform.sh` against **every** chart — no `ct`, no kind, a handful of seconds. Editing the gate proves the gate still works fleet-wide.
+[`ci-tooling.yml`](.github/workflows/ci-tooling.yml) covers all of those. It triggers on the static tier *and* on those two chart-side paths, and runs `helm unittest` + `scripts/ci/kubeconform.sh` against **every** chart — no `ct`, no kind, a handful of seconds. Editing the gate proves the gate still works fleet-wide; adding a unit-test suite gets it run.
+
+It is not a required status check, though — a path-filtered check never reports on PRs that miss the filter, so branch protection would wait on it forever (same reasoning as `actionlint.yml` below, resolved the other way). Treat a red `ci-tooling` as blocking by convention, not by mechanism.
 
 The workflows themselves are the other half: nothing validated *them*, so a typo'd `uses:`, an undefined context property or a bad `if:` expression would merge silently and surface when a release failed. [`actionlint.yml`](.github/workflows/actionlint.yml) type-checks the lot. It runs on **every** PR rather than filtering on `.github/workflows/**`: it costs seconds, and a path-filtered check can never be required by branch protection — PRs that miss the filter never report it, so the merge blocks forever waiting on a status that will never arrive.
 
@@ -175,10 +177,12 @@ Mirrored locally by `task actionlint`. Install `shellcheck` alongside actionlint
 
 ### What counts as "changed" (`use-helmignore`)
 
-`ct.yaml` sets `use-helmignore: true`, and each active chart's `.helmignore` excludes `/ci/` and `/tests/` (`nut-exporter` is deprecated and has neither directory). Those paths are test scaffolding: they are run *from the repo* and are not shipped to chart consumers. Two consequences:
+`ct.yaml` sets `use-helmignore: true`, and every chart's `.helmignore` excludes `/ci/` and `/tests/` (`nut-exporter` included, since 1.1.1 — it has a `ci/` overlay but no `tests/`). Those paths are test scaffolding: they are run *from the repo* and are not shipped to chart consumers. Two consequences:
 
 - **A test-only edit is not a chart change.** Touch only `ci/*-values.yaml` or `tests/*_test.yaml` and the chart drops out of `ct list-changed` — no version bump is demanded, and no release is published for scaffolding that consumers never receive.
-- **The flip side: that edit also gets no CI run.** No lint, no unittest, no `ct install` until the chart itself changes. A broken scenario can sit unnoticed. If you edit a scenario on its own and want it exercised now, run `task verify APP=<chart>` / `task test APP=<chart>` locally.
+- **The flip side: that edit gets no `ct` run.** No `ct lint`, no version-increment check, no `ct install` until the chart itself changes. How much else runs depends on *which* scaffolding you touched:
+  - `tests/**` and `ci/kubeconform-overlay.yaml` are in [`ci-tooling.yml`](.github/workflows/ci-tooling.yml)'s path filter, so `helm unittest` and `kubeconform` still run — fleet-wide, not just on your chart.
+  - `ci/*-values.yaml` is in no filter and consumed by no cluster-free job, so a broken `ct install` scenario sits unnoticed. Run `task test APP=<chart>` locally.
 
 Both patterns are anchored (`/ci/`, not `ci/`) on purpose: an unanchored `tests/` also matches `templates/tests/` and would strip the `helm test` hooks out of the published package.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -108,12 +108,12 @@ tasks:
     # invocation still clobbers — so refuse outright when the chart has no template.
     requires:
       vars: [APP]
+    # Also catches an APP set to the empty string, which `requires` lets through
+    # and which would point helm-docs at charts/ and regenerate the whole fleet.
+    preconditions:
+      - sh: test -f "{{.CHART_DIR}}/{{.APP}}/README.md.gotmpl"
+        msg: "no README.md.gotmpl at {{.CHART_DIR}}/{{.APP}} - either no such chart, or its README is hand-written and must not be overwritten"
     cmds:
-      - |
-        if [ ! -f "{{.CHART_DIR}}/{{.APP}}/README.md.gotmpl" ]; then
-          echo "{{.APP}} has no README.md.gotmpl - its README is hand-written, refusing to overwrite it" >&2
-          exit 1
-        fi
       - helm-docs --chart-search-root {{.CHART_DIR}}/{{.APP}}
 
   local-template:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -104,9 +104,16 @@ tasks:
     desc: Regenerate a chart's README from README.md.gotmpl via helm-docs (APP=<chart>)
     # Scoped to a single chart on purpose: charts without a README.md.gotmpl would
     # be overwritten with helm-docs' default template, clobbering hand-written READMEs.
+    # Scoping alone only prevents *incidental* regeneration — a direct APP=<chart>
+    # invocation still clobbers — so refuse outright when the chart has no template.
     requires:
       vars: [APP]
     cmds:
+      - |
+        if [ ! -f "{{.CHART_DIR}}/{{.APP}}/README.md.gotmpl" ]; then
+          echo "{{.APP}} has no README.md.gotmpl - its README is hand-written, refusing to overwrite it" >&2
+          exit 1
+        fi
       - helm-docs --chart-search-root {{.CHART_DIR}}/{{.APP}}
 
   local-template:

--- a/charts/bookstack/tests/ingress_test.yaml
+++ b/charts/bookstack/tests/ingress_test.yaml
@@ -1,0 +1,124 @@
+suite: bookstack Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: rel
+tests:
+  - it: does not render when disabled
+    asserts:
+      - hasDocuments: { count: 0 }
+
+  - it: renders the shipped defaults when enabled
+    set:
+      ingress.enabled: true
+    asserts:
+      - hasDocuments: { count: 1 }
+      - equal: { path: apiVersion, value: networking.k8s.io/v1 }
+      - equal: { path: kind, value: Ingress }
+      - equal: { path: metadata.name, value: rel-bookstack }
+      - equal: { path: "metadata.labels[\"app.kubernetes.io/name\"]", value: bookstack }
+      - equal: { path: "spec.rules[0].host", value: bookstack.example.org }
+      - equal: { path: "spec.rules[0].http.paths[0].path", value: / }
+      - equal: { path: "spec.rules[0].http.paths[0].pathType", value: Prefix }
+
+  - it: omits every optional block when unset
+    set:
+      ingress.enabled: true
+    asserts:
+      - notExists: { path: metadata.annotations }
+      - notExists: { path: spec.ingressClassName }
+      - notExists: { path: spec.tls }
+
+  - it: renders annotations and the class name when set
+    set:
+      ingress.enabled: true
+      ingress.className: nginx
+      ingress.annotations:
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+        example.com/owner: platform
+    asserts:
+      - equal: { path: spec.ingressClassName, value: nginx }
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"]
+          value: "3600"
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+
+  # Two entries with two hosts each: a single entry cannot catch a range that
+  # only ever emits its first item.
+  - it: renders every tls entry and every host inside it
+    set:
+      ingress.enabled: true
+      ingress.tls:
+        - secretName: first-tls
+          hosts:
+            - a.example.org
+            - b.example.org
+        - secretName: second-tls
+          hosts:
+            - c.example.org
+            - d.example.org
+    asserts:
+      - lengthEqual: { path: spec.tls, count: 2 }
+      - equal: { path: "spec.tls[0].secretName", value: first-tls }
+      - equal: { path: "spec.tls[0].hosts[1]", value: b.example.org }
+      - equal: { path: "spec.tls[1].secretName", value: second-tls }
+      - equal: { path: "spec.tls[1].hosts[1]", value: d.example.org }
+
+  - it: renders every host and every path within each host
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: first.example.org
+          paths:
+            - path: /
+              pathType: Prefix
+            - path: /metrics
+              pathType: Exact
+        - host: second.example.org
+          paths:
+            - path: /health
+              pathType: Exact
+    asserts:
+      - lengthEqual: { path: spec.rules, count: 2 }
+      - lengthEqual: { path: "spec.rules[0].http.paths", count: 2 }
+      - equal: { path: "spec.rules[0].host", value: first.example.org }
+      - equal: { path: "spec.rules[0].http.paths[1].path", value: /metrics }
+      - equal: { path: "spec.rules[0].http.paths[1].pathType", value: Exact }
+      - equal: { path: "spec.rules[1].host", value: second.example.org }
+      - equal: { path: "spec.rules[1].http.paths[0].path", value: /health }
+
+  # The `| default "Prefix"` arm is unreachable from this chart's own defaults,
+  # which ship an explicit pathType on every path.
+  - it: falls back to Prefix when a path omits pathType
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: first.example.org
+          paths:
+            - path: /
+    asserts:
+      - equal: { path: "spec.rules[0].http.paths[0].pathType", value: Prefix }
+
+  - it: points the backend at the Service, reading name and port from values
+    set:
+      ingress.enabled: true
+      fullnameOverride: my-exporter
+      service.port: 9999
+    asserts:
+      - equal: { path: metadata.name, value: my-exporter }
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: my-exporter
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 9999
+
+  - it: defaults the backend port to the chart's Service port
+    set:
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 80

--- a/charts/bookstack/tests/ingress_test.yaml
+++ b/charts/bookstack/tests/ingress_test.yaml
@@ -5,9 +5,13 @@ release:
   name: rel
 tests:
   - it: does not render when disabled
+    set:
+      ingress.enabled: false
     asserts:
       - hasDocuments: { count: 0 }
 
+  # Pins the values.yaml defaults deliberately: the shipped host, path and
+  # pathType are user-facing, and a silent change to them is a chart change.
   - it: renders the shipped defaults when enabled
     set:
       ingress.enabled: true
@@ -16,7 +20,16 @@ tests:
       - equal: { path: apiVersion, value: networking.k8s.io/v1 }
       - equal: { path: kind, value: Ingress }
       - equal: { path: metadata.name, value: rel-bookstack }
-      - equal: { path: "metadata.labels[\"app.kubernetes.io/name\"]", value: bookstack }
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: bookstack
+      # The full label set, not just the selector half: swapping the template's
+      # `.labels` helper for `.selectorLabels` drops these two silently.
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
       - equal: { path: "spec.rules[0].host", value: bookstack.example.org }
       - equal: { path: "spec.rules[0].http.paths[0].path", value: / }
       - equal: { path: "spec.rules[0].http.paths[0].pathType", value: Prefix }
@@ -46,14 +59,15 @@ tests:
           value: platform
 
   # Two entries with two hosts each: a single entry cannot catch a range that
-  # only ever emits its first item.
+  # only ever emits its first item. A wildcard host covers the `| quote` - the
+  # unquoted form renders a YAML alias and the document stops parsing.
   - it: renders every tls entry and every host inside it
     set:
       ingress.enabled: true
       ingress.tls:
         - secretName: first-tls
           hosts:
-            - a.example.org
+            - "*.example.org"
             - b.example.org
         - secretName: second-tls
           hosts:
@@ -62,6 +76,7 @@ tests:
     asserts:
       - lengthEqual: { path: spec.tls, count: 2 }
       - equal: { path: "spec.tls[0].secretName", value: first-tls }
+      - equal: { path: "spec.tls[0].hosts[0]", value: "*.example.org" }
       - equal: { path: "spec.tls[0].hosts[1]", value: b.example.org }
       - equal: { path: "spec.tls[1].secretName", value: second-tls }
       - equal: { path: "spec.tls[1].hosts[1]", value: d.example.org }
@@ -70,7 +85,7 @@ tests:
     set:
       ingress.enabled: true
       ingress.hosts:
-        - host: first.example.org
+        - host: "*.example.org"
           paths:
             - path: /
               pathType: Prefix
@@ -83,7 +98,7 @@ tests:
     asserts:
       - lengthEqual: { path: spec.rules, count: 2 }
       - lengthEqual: { path: "spec.rules[0].http.paths", count: 2 }
-      - equal: { path: "spec.rules[0].host", value: first.example.org }
+      - equal: { path: "spec.rules[0].host", value: "*.example.org" }
       - equal: { path: "spec.rules[0].http.paths[1].path", value: /metrics }
       - equal: { path: "spec.rules[0].http.paths[1].pathType", value: Exact }
       - equal: { path: "spec.rules[1].host", value: second.example.org }
@@ -104,13 +119,13 @@ tests:
   - it: points the backend at the Service, reading name and port from values
     set:
       ingress.enabled: true
-      fullnameOverride: my-exporter
+      fullnameOverride: custom-name
       service.port: 9999
     asserts:
-      - equal: { path: metadata.name, value: my-exporter }
+      - equal: { path: metadata.name, value: custom-name }
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
-          value: my-exporter
+          value: custom-name
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.port.number
           value: 9999

--- a/charts/pihole-exporter/tests/ingress_test.yaml
+++ b/charts/pihole-exporter/tests/ingress_test.yaml
@@ -1,0 +1,124 @@
+suite: pihole-exporter Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: rel
+tests:
+  - it: does not render when disabled
+    asserts:
+      - hasDocuments: { count: 0 }
+
+  - it: renders the shipped defaults when enabled
+    set:
+      ingress.enabled: true
+    asserts:
+      - hasDocuments: { count: 1 }
+      - equal: { path: apiVersion, value: networking.k8s.io/v1 }
+      - equal: { path: kind, value: Ingress }
+      - equal: { path: metadata.name, value: rel-pihole-exporter }
+      - equal: { path: "metadata.labels[\"app.kubernetes.io/name\"]", value: pihole-exporter }
+      - equal: { path: "spec.rules[0].host", value: chart-example.local }
+      - equal: { path: "spec.rules[0].http.paths[0].path", value: / }
+      - equal: { path: "spec.rules[0].http.paths[0].pathType", value: ImplementationSpecific }
+
+  - it: omits every optional block when unset
+    set:
+      ingress.enabled: true
+    asserts:
+      - notExists: { path: metadata.annotations }
+      - notExists: { path: spec.ingressClassName }
+      - notExists: { path: spec.tls }
+
+  - it: renders annotations and the class name when set
+    set:
+      ingress.enabled: true
+      ingress.className: nginx
+      ingress.annotations:
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+        example.com/owner: platform
+    asserts:
+      - equal: { path: spec.ingressClassName, value: nginx }
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"]
+          value: "3600"
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+
+  # Two entries with two hosts each: a single entry cannot catch a range that
+  # only ever emits its first item.
+  - it: renders every tls entry and every host inside it
+    set:
+      ingress.enabled: true
+      ingress.tls:
+        - secretName: first-tls
+          hosts:
+            - a.example.org
+            - b.example.org
+        - secretName: second-tls
+          hosts:
+            - c.example.org
+            - d.example.org
+    asserts:
+      - lengthEqual: { path: spec.tls, count: 2 }
+      - equal: { path: "spec.tls[0].secretName", value: first-tls }
+      - equal: { path: "spec.tls[0].hosts[1]", value: b.example.org }
+      - equal: { path: "spec.tls[1].secretName", value: second-tls }
+      - equal: { path: "spec.tls[1].hosts[1]", value: d.example.org }
+
+  - it: renders every host and every path within each host
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: first.example.org
+          paths:
+            - path: /
+              pathType: Prefix
+            - path: /metrics
+              pathType: Exact
+        - host: second.example.org
+          paths:
+            - path: /health
+              pathType: Exact
+    asserts:
+      - lengthEqual: { path: spec.rules, count: 2 }
+      - lengthEqual: { path: "spec.rules[0].http.paths", count: 2 }
+      - equal: { path: "spec.rules[0].host", value: first.example.org }
+      - equal: { path: "spec.rules[0].http.paths[1].path", value: /metrics }
+      - equal: { path: "spec.rules[0].http.paths[1].pathType", value: Exact }
+      - equal: { path: "spec.rules[1].host", value: second.example.org }
+      - equal: { path: "spec.rules[1].http.paths[0].path", value: /health }
+
+  # The `| default "Prefix"` arm is unreachable from this chart's own defaults,
+  # which ship an explicit pathType on every path.
+  - it: falls back to Prefix when a path omits pathType
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: first.example.org
+          paths:
+            - path: /
+    asserts:
+      - equal: { path: "spec.rules[0].http.paths[0].pathType", value: Prefix }
+
+  - it: points the backend at the Service, reading name and port from values
+    set:
+      ingress.enabled: true
+      fullnameOverride: my-exporter
+      service.port: 9999
+    asserts:
+      - equal: { path: metadata.name, value: my-exporter }
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: my-exporter
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 9999
+
+  - it: defaults the backend port to the chart's Service port
+    set:
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 9617

--- a/charts/pihole-exporter/tests/ingress_test.yaml
+++ b/charts/pihole-exporter/tests/ingress_test.yaml
@@ -5,9 +5,13 @@ release:
   name: rel
 tests:
   - it: does not render when disabled
+    set:
+      ingress.enabled: false
     asserts:
       - hasDocuments: { count: 0 }
 
+  # Pins the values.yaml defaults deliberately: the shipped host, path and
+  # pathType are user-facing, and a silent change to them is a chart change.
   - it: renders the shipped defaults when enabled
     set:
       ingress.enabled: true
@@ -16,7 +20,16 @@ tests:
       - equal: { path: apiVersion, value: networking.k8s.io/v1 }
       - equal: { path: kind, value: Ingress }
       - equal: { path: metadata.name, value: rel-pihole-exporter }
-      - equal: { path: "metadata.labels[\"app.kubernetes.io/name\"]", value: pihole-exporter }
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: pihole-exporter
+      # The full label set, not just the selector half: swapping the template's
+      # `.labels` helper for `.selectorLabels` drops these two silently.
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
       - equal: { path: "spec.rules[0].host", value: chart-example.local }
       - equal: { path: "spec.rules[0].http.paths[0].path", value: / }
       - equal: { path: "spec.rules[0].http.paths[0].pathType", value: ImplementationSpecific }
@@ -46,14 +59,15 @@ tests:
           value: platform
 
   # Two entries with two hosts each: a single entry cannot catch a range that
-  # only ever emits its first item.
+  # only ever emits its first item. A wildcard host covers the `| quote` - the
+  # unquoted form renders a YAML alias and the document stops parsing.
   - it: renders every tls entry and every host inside it
     set:
       ingress.enabled: true
       ingress.tls:
         - secretName: first-tls
           hosts:
-            - a.example.org
+            - "*.example.org"
             - b.example.org
         - secretName: second-tls
           hosts:
@@ -62,6 +76,7 @@ tests:
     asserts:
       - lengthEqual: { path: spec.tls, count: 2 }
       - equal: { path: "spec.tls[0].secretName", value: first-tls }
+      - equal: { path: "spec.tls[0].hosts[0]", value: "*.example.org" }
       - equal: { path: "spec.tls[0].hosts[1]", value: b.example.org }
       - equal: { path: "spec.tls[1].secretName", value: second-tls }
       - equal: { path: "spec.tls[1].hosts[1]", value: d.example.org }
@@ -70,7 +85,7 @@ tests:
     set:
       ingress.enabled: true
       ingress.hosts:
-        - host: first.example.org
+        - host: "*.example.org"
           paths:
             - path: /
               pathType: Prefix
@@ -83,7 +98,7 @@ tests:
     asserts:
       - lengthEqual: { path: spec.rules, count: 2 }
       - lengthEqual: { path: "spec.rules[0].http.paths", count: 2 }
-      - equal: { path: "spec.rules[0].host", value: first.example.org }
+      - equal: { path: "spec.rules[0].host", value: "*.example.org" }
       - equal: { path: "spec.rules[0].http.paths[1].path", value: /metrics }
       - equal: { path: "spec.rules[0].http.paths[1].pathType", value: Exact }
       - equal: { path: "spec.rules[1].host", value: second.example.org }
@@ -104,13 +119,13 @@ tests:
   - it: points the backend at the Service, reading name and port from values
     set:
       ingress.enabled: true
-      fullnameOverride: my-exporter
+      fullnameOverride: custom-name
       service.port: 9999
     asserts:
-      - equal: { path: metadata.name, value: my-exporter }
+      - equal: { path: metadata.name, value: custom-name }
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
-          value: my-exporter
+          value: custom-name
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.port.number
           value: 9999

--- a/charts/qbittorrent-exporter/tests/ingress_test.yaml
+++ b/charts/qbittorrent-exporter/tests/ingress_test.yaml
@@ -5,9 +5,13 @@ release:
   name: rel
 tests:
   - it: does not render when disabled
+    set:
+      ingress.enabled: false
     asserts:
       - hasDocuments: { count: 0 }
 
+  # Pins the values.yaml defaults deliberately: the shipped host, path and
+  # pathType are user-facing, and a silent change to them is a chart change.
   - it: renders the shipped defaults when enabled
     set:
       ingress.enabled: true
@@ -16,7 +20,16 @@ tests:
       - equal: { path: apiVersion, value: networking.k8s.io/v1 }
       - equal: { path: kind, value: Ingress }
       - equal: { path: metadata.name, value: rel-qbittorrent-exporter }
-      - equal: { path: "metadata.labels[\"app.kubernetes.io/name\"]", value: qbittorrent-exporter }
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: qbittorrent-exporter
+      # The full label set, not just the selector half: swapping the template's
+      # `.labels` helper for `.selectorLabels` drops these two silently.
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
       - equal: { path: "spec.rules[0].host", value: chart-example.local }
       - equal: { path: "spec.rules[0].http.paths[0].path", value: / }
       - equal: { path: "spec.rules[0].http.paths[0].pathType", value: ImplementationSpecific }
@@ -46,14 +59,15 @@ tests:
           value: platform
 
   # Two entries with two hosts each: a single entry cannot catch a range that
-  # only ever emits its first item.
+  # only ever emits its first item. A wildcard host covers the `| quote` - the
+  # unquoted form renders a YAML alias and the document stops parsing.
   - it: renders every tls entry and every host inside it
     set:
       ingress.enabled: true
       ingress.tls:
         - secretName: first-tls
           hosts:
-            - a.example.org
+            - "*.example.org"
             - b.example.org
         - secretName: second-tls
           hosts:
@@ -62,6 +76,7 @@ tests:
     asserts:
       - lengthEqual: { path: spec.tls, count: 2 }
       - equal: { path: "spec.tls[0].secretName", value: first-tls }
+      - equal: { path: "spec.tls[0].hosts[0]", value: "*.example.org" }
       - equal: { path: "spec.tls[0].hosts[1]", value: b.example.org }
       - equal: { path: "spec.tls[1].secretName", value: second-tls }
       - equal: { path: "spec.tls[1].hosts[1]", value: d.example.org }
@@ -70,7 +85,7 @@ tests:
     set:
       ingress.enabled: true
       ingress.hosts:
-        - host: first.example.org
+        - host: "*.example.org"
           paths:
             - path: /
               pathType: Prefix
@@ -83,7 +98,7 @@ tests:
     asserts:
       - lengthEqual: { path: spec.rules, count: 2 }
       - lengthEqual: { path: "spec.rules[0].http.paths", count: 2 }
-      - equal: { path: "spec.rules[0].host", value: first.example.org }
+      - equal: { path: "spec.rules[0].host", value: "*.example.org" }
       - equal: { path: "spec.rules[0].http.paths[1].path", value: /metrics }
       - equal: { path: "spec.rules[0].http.paths[1].pathType", value: Exact }
       - equal: { path: "spec.rules[1].host", value: second.example.org }
@@ -104,13 +119,13 @@ tests:
   - it: points the backend at the Service, reading name and port from values
     set:
       ingress.enabled: true
-      fullnameOverride: my-exporter
+      fullnameOverride: custom-name
       service.port: 9999
     asserts:
-      - equal: { path: metadata.name, value: my-exporter }
+      - equal: { path: metadata.name, value: custom-name }
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
-          value: my-exporter
+          value: custom-name
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.port.number
           value: 9999

--- a/charts/qbittorrent-exporter/tests/ingress_test.yaml
+++ b/charts/qbittorrent-exporter/tests/ingress_test.yaml
@@ -1,0 +1,124 @@
+suite: qbittorrent-exporter Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: rel
+tests:
+  - it: does not render when disabled
+    asserts:
+      - hasDocuments: { count: 0 }
+
+  - it: renders the shipped defaults when enabled
+    set:
+      ingress.enabled: true
+    asserts:
+      - hasDocuments: { count: 1 }
+      - equal: { path: apiVersion, value: networking.k8s.io/v1 }
+      - equal: { path: kind, value: Ingress }
+      - equal: { path: metadata.name, value: rel-qbittorrent-exporter }
+      - equal: { path: "metadata.labels[\"app.kubernetes.io/name\"]", value: qbittorrent-exporter }
+      - equal: { path: "spec.rules[0].host", value: chart-example.local }
+      - equal: { path: "spec.rules[0].http.paths[0].path", value: / }
+      - equal: { path: "spec.rules[0].http.paths[0].pathType", value: ImplementationSpecific }
+
+  - it: omits every optional block when unset
+    set:
+      ingress.enabled: true
+    asserts:
+      - notExists: { path: metadata.annotations }
+      - notExists: { path: spec.ingressClassName }
+      - notExists: { path: spec.tls }
+
+  - it: renders annotations and the class name when set
+    set:
+      ingress.enabled: true
+      ingress.className: nginx
+      ingress.annotations:
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+        example.com/owner: platform
+    asserts:
+      - equal: { path: spec.ingressClassName, value: nginx }
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"]
+          value: "3600"
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+
+  # Two entries with two hosts each: a single entry cannot catch a range that
+  # only ever emits its first item.
+  - it: renders every tls entry and every host inside it
+    set:
+      ingress.enabled: true
+      ingress.tls:
+        - secretName: first-tls
+          hosts:
+            - a.example.org
+            - b.example.org
+        - secretName: second-tls
+          hosts:
+            - c.example.org
+            - d.example.org
+    asserts:
+      - lengthEqual: { path: spec.tls, count: 2 }
+      - equal: { path: "spec.tls[0].secretName", value: first-tls }
+      - equal: { path: "spec.tls[0].hosts[1]", value: b.example.org }
+      - equal: { path: "spec.tls[1].secretName", value: second-tls }
+      - equal: { path: "spec.tls[1].hosts[1]", value: d.example.org }
+
+  - it: renders every host and every path within each host
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: first.example.org
+          paths:
+            - path: /
+              pathType: Prefix
+            - path: /metrics
+              pathType: Exact
+        - host: second.example.org
+          paths:
+            - path: /health
+              pathType: Exact
+    asserts:
+      - lengthEqual: { path: spec.rules, count: 2 }
+      - lengthEqual: { path: "spec.rules[0].http.paths", count: 2 }
+      - equal: { path: "spec.rules[0].host", value: first.example.org }
+      - equal: { path: "spec.rules[0].http.paths[1].path", value: /metrics }
+      - equal: { path: "spec.rules[0].http.paths[1].pathType", value: Exact }
+      - equal: { path: "spec.rules[1].host", value: second.example.org }
+      - equal: { path: "spec.rules[1].http.paths[0].path", value: /health }
+
+  # The `| default "Prefix"` arm is unreachable from this chart's own defaults,
+  # which ship an explicit pathType on every path.
+  - it: falls back to Prefix when a path omits pathType
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: first.example.org
+          paths:
+            - path: /
+    asserts:
+      - equal: { path: "spec.rules[0].http.paths[0].pathType", value: Prefix }
+
+  - it: points the backend at the Service, reading name and port from values
+    set:
+      ingress.enabled: true
+      fullnameOverride: my-exporter
+      service.port: 9999
+    asserts:
+      - equal: { path: metadata.name, value: my-exporter }
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: my-exporter
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 9999
+
+  - it: defaults the backend port to the chart's Service port
+    set:
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 8090

--- a/charts/tdarr-exporter/tests/ingress_test.yaml
+++ b/charts/tdarr-exporter/tests/ingress_test.yaml
@@ -5,9 +5,13 @@ release:
   name: rel
 tests:
   - it: does not render when disabled
+    set:
+      ingress.enabled: false
     asserts:
       - hasDocuments: { count: 0 }
 
+  # Pins the values.yaml defaults deliberately: the shipped host, path and
+  # pathType are user-facing, and a silent change to them is a chart change.
   - it: renders the shipped defaults when enabled
     set:
       ingress.enabled: true
@@ -16,7 +20,16 @@ tests:
       - equal: { path: apiVersion, value: networking.k8s.io/v1 }
       - equal: { path: kind, value: Ingress }
       - equal: { path: metadata.name, value: rel-tdarr-exporter }
-      - equal: { path: "metadata.labels[\"app.kubernetes.io/name\"]", value: tdarr-exporter }
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: tdarr-exporter
+      # The full label set, not just the selector half: swapping the template's
+      # `.labels` helper for `.selectorLabels` drops these two silently.
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
       - equal: { path: "spec.rules[0].host", value: chart-example.local }
       - equal: { path: "spec.rules[0].http.paths[0].path", value: / }
       - equal: { path: "spec.rules[0].http.paths[0].pathType", value: ImplementationSpecific }
@@ -46,14 +59,15 @@ tests:
           value: platform
 
   # Two entries with two hosts each: a single entry cannot catch a range that
-  # only ever emits its first item.
+  # only ever emits its first item. A wildcard host covers the `| quote` - the
+  # unquoted form renders a YAML alias and the document stops parsing.
   - it: renders every tls entry and every host inside it
     set:
       ingress.enabled: true
       ingress.tls:
         - secretName: first-tls
           hosts:
-            - a.example.org
+            - "*.example.org"
             - b.example.org
         - secretName: second-tls
           hosts:
@@ -62,6 +76,7 @@ tests:
     asserts:
       - lengthEqual: { path: spec.tls, count: 2 }
       - equal: { path: "spec.tls[0].secretName", value: first-tls }
+      - equal: { path: "spec.tls[0].hosts[0]", value: "*.example.org" }
       - equal: { path: "spec.tls[0].hosts[1]", value: b.example.org }
       - equal: { path: "spec.tls[1].secretName", value: second-tls }
       - equal: { path: "spec.tls[1].hosts[1]", value: d.example.org }
@@ -70,7 +85,7 @@ tests:
     set:
       ingress.enabled: true
       ingress.hosts:
-        - host: first.example.org
+        - host: "*.example.org"
           paths:
             - path: /
               pathType: Prefix
@@ -83,7 +98,7 @@ tests:
     asserts:
       - lengthEqual: { path: spec.rules, count: 2 }
       - lengthEqual: { path: "spec.rules[0].http.paths", count: 2 }
-      - equal: { path: "spec.rules[0].host", value: first.example.org }
+      - equal: { path: "spec.rules[0].host", value: "*.example.org" }
       - equal: { path: "spec.rules[0].http.paths[1].path", value: /metrics }
       - equal: { path: "spec.rules[0].http.paths[1].pathType", value: Exact }
       - equal: { path: "spec.rules[1].host", value: second.example.org }
@@ -104,13 +119,13 @@ tests:
   - it: points the backend at the Service, reading name and port from values
     set:
       ingress.enabled: true
-      fullnameOverride: my-exporter
+      fullnameOverride: custom-name
       service.port: 9999
     asserts:
-      - equal: { path: metadata.name, value: my-exporter }
+      - equal: { path: metadata.name, value: custom-name }
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
-          value: my-exporter
+          value: custom-name
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.port.number
           value: 9999

--- a/charts/tdarr-exporter/tests/ingress_test.yaml
+++ b/charts/tdarr-exporter/tests/ingress_test.yaml
@@ -1,0 +1,124 @@
+suite: tdarr-exporter Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: rel
+tests:
+  - it: does not render when disabled
+    asserts:
+      - hasDocuments: { count: 0 }
+
+  - it: renders the shipped defaults when enabled
+    set:
+      ingress.enabled: true
+    asserts:
+      - hasDocuments: { count: 1 }
+      - equal: { path: apiVersion, value: networking.k8s.io/v1 }
+      - equal: { path: kind, value: Ingress }
+      - equal: { path: metadata.name, value: rel-tdarr-exporter }
+      - equal: { path: "metadata.labels[\"app.kubernetes.io/name\"]", value: tdarr-exporter }
+      - equal: { path: "spec.rules[0].host", value: chart-example.local }
+      - equal: { path: "spec.rules[0].http.paths[0].path", value: / }
+      - equal: { path: "spec.rules[0].http.paths[0].pathType", value: ImplementationSpecific }
+
+  - it: omits every optional block when unset
+    set:
+      ingress.enabled: true
+    asserts:
+      - notExists: { path: metadata.annotations }
+      - notExists: { path: spec.ingressClassName }
+      - notExists: { path: spec.tls }
+
+  - it: renders annotations and the class name when set
+    set:
+      ingress.enabled: true
+      ingress.className: nginx
+      ingress.annotations:
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+        example.com/owner: platform
+    asserts:
+      - equal: { path: spec.ingressClassName, value: nginx }
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"]
+          value: "3600"
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+
+  # Two entries with two hosts each: a single entry cannot catch a range that
+  # only ever emits its first item.
+  - it: renders every tls entry and every host inside it
+    set:
+      ingress.enabled: true
+      ingress.tls:
+        - secretName: first-tls
+          hosts:
+            - a.example.org
+            - b.example.org
+        - secretName: second-tls
+          hosts:
+            - c.example.org
+            - d.example.org
+    asserts:
+      - lengthEqual: { path: spec.tls, count: 2 }
+      - equal: { path: "spec.tls[0].secretName", value: first-tls }
+      - equal: { path: "spec.tls[0].hosts[1]", value: b.example.org }
+      - equal: { path: "spec.tls[1].secretName", value: second-tls }
+      - equal: { path: "spec.tls[1].hosts[1]", value: d.example.org }
+
+  - it: renders every host and every path within each host
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: first.example.org
+          paths:
+            - path: /
+              pathType: Prefix
+            - path: /metrics
+              pathType: Exact
+        - host: second.example.org
+          paths:
+            - path: /health
+              pathType: Exact
+    asserts:
+      - lengthEqual: { path: spec.rules, count: 2 }
+      - lengthEqual: { path: "spec.rules[0].http.paths", count: 2 }
+      - equal: { path: "spec.rules[0].host", value: first.example.org }
+      - equal: { path: "spec.rules[0].http.paths[1].path", value: /metrics }
+      - equal: { path: "spec.rules[0].http.paths[1].pathType", value: Exact }
+      - equal: { path: "spec.rules[1].host", value: second.example.org }
+      - equal: { path: "spec.rules[1].http.paths[0].path", value: /health }
+
+  # The `| default "Prefix"` arm is unreachable from this chart's own defaults,
+  # which ship an explicit pathType on every path.
+  - it: falls back to Prefix when a path omits pathType
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: first.example.org
+          paths:
+            - path: /
+    asserts:
+      - equal: { path: "spec.rules[0].http.paths[0].pathType", value: Prefix }
+
+  - it: points the backend at the Service, reading name and port from values
+    set:
+      ingress.enabled: true
+      fullnameOverride: my-exporter
+      service.port: 9999
+    asserts:
+      - equal: { path: metadata.name, value: my-exporter }
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: my-exporter
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 9999
+
+  - it: defaults the backend port to the chart's Service port
+    set:
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 9090

--- a/charts/unpoller/tests/ingress_test.yaml
+++ b/charts/unpoller/tests/ingress_test.yaml
@@ -1,0 +1,124 @@
+suite: unpoller Ingress
+templates:
+  - templates/ingress.yaml
+release:
+  name: rel
+tests:
+  - it: does not render when disabled
+    asserts:
+      - hasDocuments: { count: 0 }
+
+  - it: renders the shipped defaults when enabled
+    set:
+      ingress.enabled: true
+    asserts:
+      - hasDocuments: { count: 1 }
+      - equal: { path: apiVersion, value: networking.k8s.io/v1 }
+      - equal: { path: kind, value: Ingress }
+      - equal: { path: metadata.name, value: rel-unpoller }
+      - equal: { path: "metadata.labels[\"app.kubernetes.io/name\"]", value: unpoller }
+      - equal: { path: "spec.rules[0].host", value: chart-example.local }
+      - equal: { path: "spec.rules[0].http.paths[0].path", value: / }
+      - equal: { path: "spec.rules[0].http.paths[0].pathType", value: ImplementationSpecific }
+
+  - it: omits every optional block when unset
+    set:
+      ingress.enabled: true
+    asserts:
+      - notExists: { path: metadata.annotations }
+      - notExists: { path: spec.ingressClassName }
+      - notExists: { path: spec.tls }
+
+  - it: renders annotations and the class name when set
+    set:
+      ingress.enabled: true
+      ingress.className: nginx
+      ingress.annotations:
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+        example.com/owner: platform
+    asserts:
+      - equal: { path: spec.ingressClassName, value: nginx }
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"]
+          value: "3600"
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: platform
+
+  # Two entries with two hosts each: a single entry cannot catch a range that
+  # only ever emits its first item.
+  - it: renders every tls entry and every host inside it
+    set:
+      ingress.enabled: true
+      ingress.tls:
+        - secretName: first-tls
+          hosts:
+            - a.example.org
+            - b.example.org
+        - secretName: second-tls
+          hosts:
+            - c.example.org
+            - d.example.org
+    asserts:
+      - lengthEqual: { path: spec.tls, count: 2 }
+      - equal: { path: "spec.tls[0].secretName", value: first-tls }
+      - equal: { path: "spec.tls[0].hosts[1]", value: b.example.org }
+      - equal: { path: "spec.tls[1].secretName", value: second-tls }
+      - equal: { path: "spec.tls[1].hosts[1]", value: d.example.org }
+
+  - it: renders every host and every path within each host
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: first.example.org
+          paths:
+            - path: /
+              pathType: Prefix
+            - path: /metrics
+              pathType: Exact
+        - host: second.example.org
+          paths:
+            - path: /health
+              pathType: Exact
+    asserts:
+      - lengthEqual: { path: spec.rules, count: 2 }
+      - lengthEqual: { path: "spec.rules[0].http.paths", count: 2 }
+      - equal: { path: "spec.rules[0].host", value: first.example.org }
+      - equal: { path: "spec.rules[0].http.paths[1].path", value: /metrics }
+      - equal: { path: "spec.rules[0].http.paths[1].pathType", value: Exact }
+      - equal: { path: "spec.rules[1].host", value: second.example.org }
+      - equal: { path: "spec.rules[1].http.paths[0].path", value: /health }
+
+  # The `| default "Prefix"` arm is unreachable from this chart's own defaults,
+  # which ship an explicit pathType on every path.
+  - it: falls back to Prefix when a path omits pathType
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - host: first.example.org
+          paths:
+            - path: /
+    asserts:
+      - equal: { path: "spec.rules[0].http.paths[0].pathType", value: Prefix }
+
+  - it: points the backend at the Service, reading name and port from values
+    set:
+      ingress.enabled: true
+      fullnameOverride: my-exporter
+      service.port: 9999
+    asserts:
+      - equal: { path: metadata.name, value: my-exporter }
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: my-exporter
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 9999
+
+  - it: defaults the backend port to the chart's Service port
+    set:
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 9130

--- a/charts/unpoller/tests/ingress_test.yaml
+++ b/charts/unpoller/tests/ingress_test.yaml
@@ -5,9 +5,13 @@ release:
   name: rel
 tests:
   - it: does not render when disabled
+    set:
+      ingress.enabled: false
     asserts:
       - hasDocuments: { count: 0 }
 
+  # Pins the values.yaml defaults deliberately: the shipped host, path and
+  # pathType are user-facing, and a silent change to them is a chart change.
   - it: renders the shipped defaults when enabled
     set:
       ingress.enabled: true
@@ -16,7 +20,16 @@ tests:
       - equal: { path: apiVersion, value: networking.k8s.io/v1 }
       - equal: { path: kind, value: Ingress }
       - equal: { path: metadata.name, value: rel-unpoller }
-      - equal: { path: "metadata.labels[\"app.kubernetes.io/name\"]", value: unpoller }
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: unpoller
+      # The full label set, not just the selector half: swapping the template's
+      # `.labels` helper for `.selectorLabels` drops these two silently.
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
       - equal: { path: "spec.rules[0].host", value: chart-example.local }
       - equal: { path: "spec.rules[0].http.paths[0].path", value: / }
       - equal: { path: "spec.rules[0].http.paths[0].pathType", value: ImplementationSpecific }
@@ -46,14 +59,15 @@ tests:
           value: platform
 
   # Two entries with two hosts each: a single entry cannot catch a range that
-  # only ever emits its first item.
+  # only ever emits its first item. A wildcard host covers the `| quote` - the
+  # unquoted form renders a YAML alias and the document stops parsing.
   - it: renders every tls entry and every host inside it
     set:
       ingress.enabled: true
       ingress.tls:
         - secretName: first-tls
           hosts:
-            - a.example.org
+            - "*.example.org"
             - b.example.org
         - secretName: second-tls
           hosts:
@@ -62,6 +76,7 @@ tests:
     asserts:
       - lengthEqual: { path: spec.tls, count: 2 }
       - equal: { path: "spec.tls[0].secretName", value: first-tls }
+      - equal: { path: "spec.tls[0].hosts[0]", value: "*.example.org" }
       - equal: { path: "spec.tls[0].hosts[1]", value: b.example.org }
       - equal: { path: "spec.tls[1].secretName", value: second-tls }
       - equal: { path: "spec.tls[1].hosts[1]", value: d.example.org }
@@ -70,7 +85,7 @@ tests:
     set:
       ingress.enabled: true
       ingress.hosts:
-        - host: first.example.org
+        - host: "*.example.org"
           paths:
             - path: /
               pathType: Prefix
@@ -83,7 +98,7 @@ tests:
     asserts:
       - lengthEqual: { path: spec.rules, count: 2 }
       - lengthEqual: { path: "spec.rules[0].http.paths", count: 2 }
-      - equal: { path: "spec.rules[0].host", value: first.example.org }
+      - equal: { path: "spec.rules[0].host", value: "*.example.org" }
       - equal: { path: "spec.rules[0].http.paths[1].path", value: /metrics }
       - equal: { path: "spec.rules[0].http.paths[1].pathType", value: Exact }
       - equal: { path: "spec.rules[1].host", value: second.example.org }
@@ -104,13 +119,13 @@ tests:
   - it: points the backend at the Service, reading name and port from values
     set:
       ingress.enabled: true
-      fullnameOverride: my-exporter
+      fullnameOverride: custom-name
       service.port: 9999
     asserts:
-      - equal: { path: metadata.name, value: my-exporter }
+      - equal: { path: metadata.name, value: custom-name }
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.name
-          value: my-exporter
+          value: custom-name
       - equal:
           path: spec.rules[0].http.paths[0].backend.service.port.number
           value: 9999


### PR DESCRIPTION
Closes the first slice of the fleet follow-up backlog's "per-template unit tests for omissions" item, plus the `task docs` footgun.

No chart version bumps: unit-test suites are helmignored and ship in no package, and `Taskfile.yml` / `.github/` are not charts. Nothing here reaches a chart consumer.

## Changes

**`charts/*/tests/**` added to `ci-tooling.yml`'s path filter.** A PR whose only change is a unit-test suite ran in *no* CI job. `ct.yaml` sets `use-helmignore: true` and `/tests/` is helmignored in every chart, so the chart drops out of `ct list-changed` and every step in `ci.yml` skips; `ci-tooling.yml` already runs `helm unittest` fleet-wide but did not list the test directories, so it never triggered either. Same failure mode, and the same fix, as the per-chart kubeconform overlays directly above it in the filter.

**`ingress_test.yaml` in the five charts that ship an Ingress** (bookstack, pihole-exporter, qbittorrent-exporter, tdarr-exporter, unpoller), nine cases each. `ingress.yaml` had zero unit-test coverage fleet-wide while its sibling `httproute.yaml` had a suite in all five. Static analysis cannot reach this class: a dropped optional block is still schema-valid, so kubeconform passes on output that silently lost the user's annotations, TLS entries or extra hosts.

The five templates are byte-identical apart from the helper prefix (verified: normalising the chart name yields one hash for all five), so the suites are too, differing only in each chart's Service port and shipped ingress defaults. Each covers both arms of every conditional — the `enabled` gate, the `annotations` / `className` / `tls` `with` blocks, and the `pathType | default "Prefix"` fallback, which no chart's own defaults reach because all five ship an explicit `pathType`. The `tls` and `hosts` cases use two entries with two children each; one entry cannot catch a range that only ever emits its first item.

**`task docs` refuses charts with no `README.md.gotmpl`.** The old comment claimed per-chart scoping protected them. It only prevents *incidental* regeneration — a direct `task docs APP=nut-exporter` replaced that chart's hand-written deprecation README, warning banner and upstream migration table included, with helm-docs' default output. Confirmed in a throwaway copy. Implemented with go-task's `preconditions`, which also closes a second hole: `requires: vars:` passes an empty string, so `task docs APP=` pointed helm-docs at `charts/` and regenerated the whole fleet.

**Documentation corrected where this branch invalidated it.** `CONTRIBUTING.md` told contributors a test-only edit gets "no lint, no unittest, no `ct install`" — the unittest half stopped being true here. The claim is now split by path: `tests/**` and `ci/kubeconform-overlay.yaml` run unittest + kubeconform fleet-wide, while `ci/*-values.yaml` is in no filter and remains verifiable only with `task test` locally. Also records that `ci-tooling.yml` is not a required status check, and corrects the `nut-exporter` parenthetical — it gained both `.helmignore` entries in 1.1.1 and does have a `ci/` directory.

## Motivation

Unit tests are the half of the coverage problem static analysis provably cannot reach. kubeconform validates what *was* rendered; it has nothing to say about a field that should have been rendered and was not. `imagePullSecrets` missing from a pod spec is schema-valid.

`ingress.yaml` was the largest instance: five charts, zero tests, while the sibling template covering the same job had full coverage. Its `pathType` fallback was reachable only through the kubeconform overlay.

## Test plan

- `helm unittest` + `scripts/ci/kubeconform.sh` over all nine charts (the exact loop `ci-tooling.yml` runs) — green, 340 tests.
- Each new suite verified to have teeth by reintroducing defects into the template and confirming failure, then restoring: `nindent` → `indent` on annotations, the `pathType` default dropped, the backend port hardcoded, the tls host range truncated to its first item, the `.labels` helper swapped for `.selectorLabels`, and `| quote` dropped from each host field.
- `task docs APP=nut-exporter` refuses; `APP=does-not-exist`, `APP=` and `APP=nut-exporter/` each refuse with the right message; `APP` unset fails on the required var; `APP=bookstack` still regenerates with zero README drift.
- actionlint (the digest-pinned image `actionlint.yml` uses) clean.
- The path-filter premise confirmed directly: `ct list-changed` returns nothing for this branch's diff with `use-helmignore: true`, and all five charts with it off.

## In-depth

**Reviewed by three independent passes** — Helm/helm-unittest idiom, test teeth and branch coverage, CI wiring and dev tooling. Two found substance.

The coverage pass ran 24 template mutations against the first version of the suites and found three regressions that stayed green:

- Only `app.kubernetes.io/name` was asserted — a label that both the `.labels` and `.selectorLabels` helpers emit — so swapping the helper silently dropped `helm.sh/chart`, `app.kubernetes.io/version` and `managed-by` with every test still passing. Now also asserts `managed-by` by value and `helm.sh/chart` by *existence*; existence deliberately, because its value carries the chart version and a value assertion would turn every version bump into a test edit.
- Dropping `| quote` on the rules host or a tls host left every test green, but renders a wildcard host as a YAML alias and the document stops parsing. Both multi-entry cases now lead with `*.example.org`.

The CI pass blocked on documentation rather than code, which is why the `docs:` commit exists.

**Known gaps, deliberately not closed here:**

- Nothing constrains *additions* to a rendered document — injecting a `namespace` into the Ingress metadata survives green. A single `matchSnapshot` on the fully-populated case would close that class. `matchSnapshot` is currently used zero times fleet-wide.
- A host entry with no `paths` key renders `paths: null`, which fails `kubeconform -strict`. It is a template defect, not a test gap, and fixing it needs a chart version bump.
- `pihole-exporter`, `qbittorrent-exporter`, `tdarr-exporter` and `unpoller` have no `# --` helm-docs comments on their `ingress:` values block at all, so those rows are missing from the generated README value tables. Fixing it edits `values.yaml` in four charts, so it needs its own PR and four version bumps.
- `README.md.gotmpl` is helmignored in eight charts and no workflow runs helm-docs, so README drift is ungated — the same blind-spot class this PR closes for `tests/`.

**Follow-up:** `service.yaml` is untested in seven of eight charts that ship it, and `serviceaccount.yaml` in five. Those are the remaining slices of the same backlog item.
