### PR TITLE
test: cover the omissions static analysis cannot see

### DIFF
--- a/charts/bookstack-file-exporter/tests/cronjob_test.yaml
+++ b/charts/bookstack-file-exporter/tests/cronjob_test.yaml
@@ -148,3 +148,94 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.template.spec.automountServiceAccountToken
           value: false
+
+  # Optional pod-spec blocks. Static validation cannot see these: a pod spec
+  # missing imagePullSecrets is schema-valid, so only a unit test catches a
+  # `with` block that stopped rendering. Both directions are pinned - absent
+  # when unset, and every entry present when set.
+  - it: omits every optional pod-spec block when unset
+    asserts:
+      - notExists: { path: spec.jobTemplate.spec.template.spec.nodeSelector }
+      - notExists: { path: spec.jobTemplate.spec.template.spec.affinity }
+      - notExists: { path: spec.jobTemplate.spec.template.spec.tolerations }
+      - notExists: { path: spec.jobTemplate.spec.template.metadata.annotations }
+
+  # Two entries per list on purpose: one entry cannot catch a range that only
+  # ever emits its first item, and two map keys catch a `toYaml` swapped for a
+  # single-key interpolation. Lengths are pinned too, so a spurious third entry
+  # fails rather than passing on the two that were checked.
+  - it: renders every entry of every optional pod-spec block when set
+    set:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        topology.kubernetes.io/zone: us-east-1a
+      tolerations:
+        - key: first-taint
+          operator: Exists
+          effect: NoSchedule
+        - key: second-taint
+          operator: Exists
+          effect: NoExecute
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                      - windows
+      podLabels:
+        first-label: one
+        second-label: two
+      podAnnotations:
+        first-annotation: one
+        second-annotation: two
+      volumes:
+        - name: first-extra
+          emptyDir: {}
+        - name: second-extra
+          emptyDir: {}
+      volumeMounts:
+        - name: first-extra
+          mountPath: /first
+        - name: second-extra
+          mountPath: /second
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.nodeSelector["kubernetes.io/arch"]
+          value: amd64
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.nodeSelector["topology.kubernetes.io/zone"]
+          value: us-east-1a
+      - lengthEqual: { path: "spec.jobTemplate.spec.template.spec.tolerations", count: 2 }
+      - equal: { path: "spec.jobTemplate.spec.template.spec.tolerations[0].key", value: first-taint }
+      - equal: { path: "spec.jobTemplate.spec.template.spec.tolerations[1].key", value: second-taint }
+      - equal:
+          path: "spec.jobTemplate.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[1]"
+          value: windows
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.labels["first-label"]
+          value: one
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.labels["second-label"]
+          value: two
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.annotations["first-annotation"]
+          value: one
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.annotations["second-annotation"]
+          value: two
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.volumes
+          content: { name: first-extra, emptyDir: {} }
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.volumes
+          content: { name: second-extra, emptyDir: {} }
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts
+          content: { name: first-extra, mountPath: /first }
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts
+          content: { name: second-extra, mountPath: /second }

--- a/charts/bookstack-file-exporter/tests/deployment_test.yaml
+++ b/charts/bookstack-file-exporter/tests/deployment_test.yaml
@@ -215,3 +215,109 @@ tests:
     asserts:
       - exists: { path: spec.template.spec.serviceAccountName }
       - equal: { path: spec.template.spec.automountServiceAccountToken, value: false }
+
+  # Optional pod-spec blocks on the Deployment path. Its sibling CronJob suite
+  # pins these, but this template renders only when config.run_interval > 0 and
+  # had no coverage of them at all - 13 `with` passthroughs, none asserted.
+  - it: omits every optional pod-spec block when unset
+    template: templates/deployment.yaml
+    set:
+      config.run_interval: 60
+    asserts:
+      - notExists: { path: spec.template.spec.imagePullSecrets }
+      - notExists: { path: spec.template.spec.nodeSelector }
+      - notExists: { path: spec.template.spec.affinity }
+      - notExists: { path: spec.template.spec.tolerations }
+      # The annotations key is never absent here: the template always writes a
+      # checksum/config annotation so a ConfigMap change rolls the pod. Losing it
+      # silently stops config reloads, so pin its presence rather than absence.
+      - exists:
+          path: spec.template.metadata.annotations["checksum/config"]
+
+  # Two entries per list on purpose: one entry cannot catch a range that only
+  # ever emits its first item. Volumes are asserted with `contains` because the
+  # chart already mounts its config volume by default, so an index would be
+  # brittle.
+  - it: renders every entry of every optional pod-spec block when set
+    template: templates/deployment.yaml
+    set:
+      config.run_interval: 60
+      imagePullSecrets:
+        - name: first-registry
+        - name: second-registry
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        topology.kubernetes.io/zone: us-east-1a
+      tolerations:
+        - key: first-taint
+          operator: Exists
+          effect: NoSchedule
+        - key: second-taint
+          operator: Exists
+          effect: NoExecute
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                      - windows
+      podLabels:
+        first-label: one
+        second-label: two
+      podAnnotations:
+        first-annotation: one
+        second-annotation: two
+      volumes:
+        - name: first-extra
+          emptyDir: {}
+        - name: second-extra
+          emptyDir: {}
+      volumeMounts:
+        - name: first-extra
+          mountPath: /first
+        - name: second-extra
+          mountPath: /second
+    asserts:
+      - lengthEqual: { path: "spec.template.spec.imagePullSecrets", count: 2 }
+      - equal: { path: "spec.template.spec.imagePullSecrets[0].name", value: first-registry }
+      - equal: { path: "spec.template.spec.imagePullSecrets[1].name", value: second-registry }
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/arch"]
+          value: amd64
+      - equal:
+          path: spec.template.spec.nodeSelector["topology.kubernetes.io/zone"]
+          value: us-east-1a
+      - lengthEqual: { path: "spec.template.spec.tolerations", count: 2 }
+      - equal: { path: "spec.template.spec.tolerations[0].key", value: first-taint }
+      - equal: { path: "spec.template.spec.tolerations[1].key", value: second-taint }
+      - equal:
+          path: "spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[1]"
+          value: windows
+      - equal:
+          path: spec.template.metadata.labels["first-label"]
+          value: one
+      - equal:
+          path: spec.template.metadata.labels["second-label"]
+          value: two
+      - equal:
+          path: spec.template.metadata.annotations["first-annotation"]
+          value: one
+      - equal:
+          path: spec.template.metadata.annotations["second-annotation"]
+          value: two
+      - contains:
+          path: spec.template.spec.volumes
+          content: { name: first-extra, emptyDir: {} }
+      - contains:
+          path: spec.template.spec.volumes
+          content: { name: second-extra, emptyDir: {} }
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: { name: first-extra, mountPath: /first }
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: { name: second-extra, mountPath: /second }

--- a/charts/bookstack/tests/deployment_test.yaml
+++ b/charts/bookstack/tests/deployment_test.yaml
@@ -77,3 +77,85 @@ tests:
     asserts:
       - exists: { path: spec.template.spec.serviceAccountName }
       - equal: { path: spec.template.spec.automountServiceAccountToken, value: false }
+
+  # Optional pod-spec blocks. Static validation cannot see these: a pod spec
+  # missing imagePullSecrets is schema-valid, so only a unit test catches a
+  # `with` block that stopped rendering. Both directions are pinned - absent
+  # when unset, and every entry present when set.
+  - it: omits every optional pod-spec block when unset
+    asserts:
+      - notExists: { path: spec.template.spec.imagePullSecrets }
+      - notExists: { path: spec.template.spec.nodeSelector }
+      - notExists: { path: spec.template.spec.affinity }
+      - notExists: { path: spec.template.spec.tolerations }
+      - notExists: { path: spec.template.metadata.annotations }
+
+  # updateStrategy is a `with` block with a NON-empty default, so losing it
+  # does not omit a feature - it silently flips the workload to RollingUpdate.
+  - it: keeps the Recreate update strategy by default
+    asserts:
+      - equal: { path: spec.strategy.type, value: Recreate }
+
+  # Two entries per list on purpose: one entry cannot catch a range that only
+  # ever emits its first item, and two map keys catch a `toYaml` swapped for a
+  # single-key interpolation. Lengths are pinned too, so a spurious third entry
+  # fails rather than passing on the two that were checked.
+  - it: renders every entry of every optional pod-spec block when set
+    set:
+      imagePullSecrets:
+        - name: first-registry
+        - name: second-registry
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        topology.kubernetes.io/zone: us-east-1a
+      tolerations:
+        - key: first-taint
+          operator: Exists
+          effect: NoSchedule
+        - key: second-taint
+          operator: Exists
+          effect: NoExecute
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                      - windows
+      podLabels:
+        first-label: one
+        second-label: two
+      podAnnotations:
+        first-annotation: one
+        second-annotation: two
+    asserts:
+      - lengthEqual: { path: "spec.template.spec.imagePullSecrets", count: 2 }
+      - equal: { path: "spec.template.spec.imagePullSecrets[0].name", value: first-registry }
+      - equal: { path: "spec.template.spec.imagePullSecrets[1].name", value: second-registry }
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/arch"]
+          value: amd64
+      - equal:
+          path: spec.template.spec.nodeSelector["topology.kubernetes.io/zone"]
+          value: us-east-1a
+      - lengthEqual: { path: "spec.template.spec.tolerations", count: 2 }
+      - equal: { path: "spec.template.spec.tolerations[0].key", value: first-taint }
+      - equal: { path: "spec.template.spec.tolerations[1].key", value: second-taint }
+      - equal:
+          path: "spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[1]"
+          value: windows
+      - equal:
+          path: spec.template.metadata.labels["first-label"]
+          value: one
+      - equal:
+          path: spec.template.metadata.labels["second-label"]
+          value: two
+      - equal:
+          path: spec.template.metadata.annotations["first-annotation"]
+          value: one
+      - equal:
+          path: spec.template.metadata.annotations["second-annotation"]
+          value: two

--- a/charts/bookstack/tests/service_test.yaml
+++ b/charts/bookstack/tests/service_test.yaml
@@ -1,0 +1,72 @@
+suite: bookstack Service
+templates:
+  - templates/service.yaml
+release:
+  name: rel
+tests:
+  - it: renders one Service named for the chart fullname
+    asserts:
+      - hasDocuments: { count: 1 }
+      - isKind: { of: Service }
+      - equal: { path: metadata.name, value: rel-bookstack }
+
+  # Unlike the exporter charts, this Service targets a *named* container port:
+  # `targetPort` and the port's `name` both come from service.portName.
+  - it: targets the container port by name, not by number
+    asserts:
+      - equal: { path: "spec.ports[0].port", value: 80 }
+      - equal: { path: "spec.ports[0].targetPort", value: http }
+      - equal: { path: "spec.ports[0].name", value: http }
+      - equal: { path: "spec.ports[0].protocol", value: TCP }
+      - equal: { path: spec.type, value: ClusterIP }
+
+  - it: honours the service value overrides
+    set:
+      service.type: NodePort
+      service.port: 8080
+      service.portName: web
+    asserts:
+      - equal: { path: spec.type, value: NodePort }
+      - equal: { path: "spec.ports[0].port", value: 8080 }
+      - equal: { path: "spec.ports[0].targetPort", value: web }
+      - equal: { path: "spec.ports[0].name", value: web }
+
+  # The template quotes both fields, which is what keeps the value a string. A
+  # digits-only portName is not a legal IANA_SVC_NAME, so this is a type-stability
+  # guard rather than a reachable bug: dropping the quotes silently turns the
+  # rendered targetPort into an integer, which is a different Service.
+  - it: keeps a numeric-looking portName a string
+    set:
+      service.portName: "8080"
+    asserts:
+      - isType: { path: "spec.ports[0].targetPort", type: string }
+      - equal: { path: "spec.ports[0].targetPort", value: "8080" }
+      - equal: { path: "spec.ports[0].name", value: "8080" }
+
+  # The selector must stay the `selectorLabels` subset. Swapping it for the full
+  # `labels` helper bakes helm.sh/chart and app.kubernetes.io/version into the
+  # selector, which then changes on every chart bump - the Service silently
+  # stops matching any pod whose template labels were rendered by an older
+  # revision.
+  - it: selects on the selector-label subset only
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: bookstack
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: rel
+      - notExists:
+          path: spec.selector["helm.sh/chart"]
+      - notExists:
+          path: spec.selector["app.kubernetes.io/version"]
+      - notExists:
+          path: spec.selector["app.kubernetes.io/managed-by"]
+
+  - it: carries the full label set on metadata
+    asserts:
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm

--- a/charts/exportarr/tests/deployment_test.yaml
+++ b/charts/exportarr/tests/deployment_test.yaml
@@ -215,3 +215,147 @@ tests:
           path: spec.template.metadata.annotations["prometheus.io/scrape"]
       - exists:
           path: spec.template.spec.serviceAccountName
+
+  # Optional pod-spec blocks. Static validation cannot see these: a pod spec
+  # missing imagePullSecrets is schema-valid, so only a unit test catches a
+  # `with` block that stopped rendering. Both directions are pinned - absent
+  # when unset, and every entry present when set.
+  - it: omits every optional pod-spec block when unset
+    set:
+      exportarr.apps.radarr[0]:
+        name: main
+        enabled: true
+        url: http://radarr:7878
+    asserts:
+      - notExists: { path: spec.template.spec.imagePullSecrets }
+      - notExists: { path: spec.template.spec.nodeSelector }
+      - notExists: { path: spec.template.spec.affinity }
+      - notExists: { path: spec.template.spec.tolerations }
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  # updateStrategy is a `with` block with a NON-empty default, so losing it
+  # does not omit a feature - it silently flips the workload to RollingUpdate.
+  - it: keeps the Recreate update strategy by default
+    set:
+      exportarr.apps.radarr[0]:
+        name: main
+        enabled: true
+        url: http://radarr:7878
+    asserts:
+      - equal: { path: spec.strategy.type, value: Recreate }
+
+  # Two entries per list on purpose: one entry cannot catch a range that only
+  # ever emits its first item, and two map keys catch a `toYaml` swapped for a
+  # single-key interpolation. Lengths are pinned too, so a spurious third entry
+  # fails rather than passing on the two that were checked.
+  - it: renders every entry of every optional pod-spec block when set
+    set:
+      exportarr.apps.radarr[0]:
+        name: main
+        enabled: true
+        url: http://radarr:7878
+        volumes:
+          - name: per-app-extra
+            emptyDir: {}
+        volumeMounts:
+          - name: per-app-extra
+            mountPath: /per-app
+      exportarr.imagePullSecrets:
+        - name: first-registry
+        - name: second-registry
+      exportarr.nodeSelector:
+        kubernetes.io/arch: amd64
+        topology.kubernetes.io/zone: us-east-1a
+      exportarr.tolerations:
+        - key: first-taint
+          operator: Exists
+          effect: NoSchedule
+        - key: second-taint
+          operator: Exists
+          effect: NoExecute
+      exportarr.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                      - windows
+      exportarr.podLabels:
+        first-label: one
+        second-label: two
+      exportarr.podAnnotations:
+        first-annotation: one
+        second-annotation: two
+      exportarr.volumes:
+        - name: global-extra
+          emptyDir: {}
+      exportarr.volumeMounts:
+        - name: global-extra
+          mountPath: /global
+    asserts:
+      - lengthEqual: { path: "spec.template.spec.imagePullSecrets", count: 2 }
+      - equal: { path: "spec.template.spec.imagePullSecrets[0].name", value: first-registry }
+      - equal: { path: "spec.template.spec.imagePullSecrets[1].name", value: second-registry }
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/arch"]
+          value: amd64
+      - equal:
+          path: spec.template.spec.nodeSelector["topology.kubernetes.io/zone"]
+          value: us-east-1a
+      - lengthEqual: { path: "spec.template.spec.tolerations", count: 2 }
+      - equal: { path: "spec.template.spec.tolerations[0].key", value: first-taint }
+      - equal: { path: "spec.template.spec.tolerations[1].key", value: second-taint }
+      - equal:
+          path: "spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[1]"
+          value: windows
+      - equal:
+          path: spec.template.metadata.labels["first-label"]
+          value: one
+      - equal:
+          path: spec.template.metadata.labels["second-label"]
+          value: two
+      - equal:
+          path: spec.template.metadata.annotations["first-annotation"]
+          value: one
+      - equal:
+          path: spec.template.metadata.annotations["second-annotation"]
+          value: two
+      - contains:
+          path: spec.template.spec.volumes
+          content: { name: global-extra, emptyDir: {} }
+      - contains:
+          path: spec.template.spec.volumes
+          content: { name: per-app-extra, emptyDir: {} }
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: { name: global-extra, mountPath: /global }
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: { name: per-app-extra, mountPath: /per-app }
+
+  # The component label is the only thing separating one instance's pods from
+  # another's - every instance shares the same name/instance selector labels.
+  # All three sites are pinned because dropping either of the selector-side ones
+  # is silent: the Deployment still rolls, and its Service then selects the
+  # wrong pods or none at all.
+  - it: carries the per-instance component label on all three selector sites
+    set:
+      exportarr.apps.radarr[0]:
+        name: main
+        enabled: true
+        url: http://radarr:7878
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: ex-exportarr-radarr-main
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: ex-exportarr-radarr-main
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: ex-exportarr-radarr-main

--- a/charts/exportarr/tests/service_test.yaml
+++ b/charts/exportarr/tests/service_test.yaml
@@ -1,0 +1,106 @@
+suite: exportarr Service
+templates:
+  - templates/service.yaml
+release:
+  name: ex
+tests:
+  - it: renders no Service when no instance is enabled
+    asserts:
+      - hasDocuments: { count: 0 }
+
+  - it: renders no Service for an instance that is disabled
+    set:
+      exportarr.apps.radarr[0]:
+        name: main
+        enabled: false
+        url: http://radarr:7878
+    asserts:
+      - hasDocuments: { count: 0 }
+
+  # Two instances across two app types on purpose: the name is built from the
+  # apps map key *and* the per-instance name, so a template that dropped either
+  # half would still render a unique-looking name for a single-instance install
+  # and only collide once a second instance exists.
+  - it: renders one Service per enabled instance, named app-key-instance
+    set:
+      exportarr.apps.radarr[0]:
+        name: main
+        enabled: true
+        url: http://radarr:7878
+      exportarr.apps.sonarr[0]:
+        name: second
+        enabled: true
+        url: http://sonarr:8989
+    asserts:
+      - hasDocuments: { count: 2 }
+      - exists:
+          path: metadata.name
+        documentSelector:
+          path: metadata.name
+          value: ex-exportarr-radarr-main
+      - exists:
+          path: metadata.name
+        documentSelector:
+          path: metadata.name
+          value: ex-exportarr-sonarr-second
+
+  - it: wires port, targetPort, protocol and name from values
+    set:
+      exportarr.apps.radarr[0]:
+        name: main
+        enabled: true
+        url: http://radarr:7878
+    asserts:
+      - equal: { path: "spec.ports[0].port", value: 9707 }
+      - equal: { path: "spec.ports[0].targetPort", value: 9707 }
+      - equal: { path: "spec.ports[0].protocol", value: TCP }
+      - equal: { path: "spec.ports[0].name", value: metrics }
+      - equal: { path: spec.type, value: ClusterIP }
+
+  - it: honours the service value overrides
+    set:
+      exportarr.service.type: LoadBalancer
+      exportarr.service.port: 18080
+      exportarr.service.protocol: UDP
+      exportarr.service.name: custom
+      exportarr.apps.radarr[0]:
+        name: main
+        enabled: true
+        url: http://radarr:7878
+    asserts:
+      - equal: { path: spec.type, value: LoadBalancer }
+      - equal: { path: "spec.ports[0].port", value: 18080 }
+      - equal: { path: "spec.ports[0].targetPort", value: 18080 }
+      - equal: { path: "spec.ports[0].protocol", value: UDP }
+      - equal: { path: "spec.ports[0].name", value: custom }
+
+  # The component label is what keeps one instance's Service from selecting
+  # another instance's pods - every instance shares the same name/instance
+  # selector labels, so without it a two-instance install cross-wires. Asserted
+  # on the selector, not just on metadata: only the selector half affects
+  # routing.
+  - it: scopes the selector to the instance with the component label
+    set:
+      exportarr.apps.radarr[0]:
+        name: main
+        enabled: true
+        url: http://radarr:7878
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: ex-exportarr-radarr-main
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: ex-exportarr-radarr-main
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: exportarr
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: ex
+      - notExists:
+          path: spec.selector["helm.sh/chart"]
+      - notExists:
+          path: spec.selector["app.kubernetes.io/version"]
+      - notExists:
+          path: spec.selector["app.kubernetes.io/managed-by"]

--- a/charts/exportarr/tests/service_test.yaml
+++ b/charts/exportarr/tests/service_test.yaml
@@ -33,13 +33,19 @@ tests:
         url: http://sonarr:8989
     asserts:
       - hasDocuments: { count: 2 }
-      - exists:
-          path: metadata.name
+      # documentSelector fails outright when nothing matches, so selecting on
+      # the name already proves the name. Each selected document then asserts
+      # the selector half, which is what actually keeps the two instances from
+      # cross-wiring onto each other's pods.
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: ex-exportarr-radarr-main
         documentSelector:
           path: metadata.name
           value: ex-exportarr-radarr-main
-      - exists:
-          path: metadata.name
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: ex-exportarr-sonarr-second
         documentSelector:
           path: metadata.name
           value: ex-exportarr-sonarr-second

--- a/charts/pihole-exporter/tests/deployment_test.yaml
+++ b/charts/pihole-exporter/tests/deployment_test.yaml
@@ -73,3 +73,111 @@ tests:
     asserts:
       - exists: { path: spec.template.spec.serviceAccountName }
       - equal: { path: spec.template.spec.automountServiceAccountToken, value: false }
+
+  # Optional pod-spec blocks. Static validation cannot see these: a pod spec
+  # missing imagePullSecrets is schema-valid, so only a unit test catches a
+  # `with` block that stopped rendering. Both directions are pinned - absent
+  # when unset, and every entry present when set.
+  - it: omits every optional pod-spec block when unset
+    asserts:
+      - notExists: { path: spec.template.spec.imagePullSecrets }
+      - notExists: { path: spec.template.spec.nodeSelector }
+      - notExists: { path: spec.template.spec.affinity }
+      - notExists: { path: spec.template.spec.tolerations }
+      - notExists: { path: spec.template.spec.volumes }
+      - notExists: { path: "spec.template.spec.containers[0].volumeMounts" }
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  # updateStrategy is a `with` block with a NON-empty default, so losing it
+  # does not omit a feature - it silently flips the workload to RollingUpdate.
+  - it: keeps the Recreate update strategy by default
+    asserts:
+      - equal: { path: spec.strategy.type, value: Recreate }
+
+  # Two entries per list on purpose: one entry cannot catch a range that only
+  # ever emits its first item, and two map keys catch a `toYaml` swapped for a
+  # single-key interpolation. Lengths are pinned too, so a spurious third entry
+  # fails rather than passing on the two that were checked.
+  - it: renders every entry of every optional pod-spec block when set
+    set:
+      imagePullSecrets:
+        - name: first-registry
+        - name: second-registry
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        topology.kubernetes.io/zone: us-east-1a
+      tolerations:
+        - key: first-taint
+          operator: Exists
+          effect: NoSchedule
+        - key: second-taint
+          operator: Exists
+          effect: NoExecute
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                      - windows
+      podLabels:
+        first-label: one
+        second-label: two
+      podAnnotations:
+        first-annotation: one
+        second-annotation: two
+      volumes:
+        - name: first-extra
+          emptyDir: {}
+        - name: second-extra
+          emptyDir: {}
+      volumeMounts:
+        - name: first-extra
+          mountPath: /first
+        - name: second-extra
+          mountPath: /second
+    asserts:
+      - lengthEqual: { path: "spec.template.spec.imagePullSecrets", count: 2 }
+      - equal: { path: "spec.template.spec.imagePullSecrets[0].name", value: first-registry }
+      - equal: { path: "spec.template.spec.imagePullSecrets[1].name", value: second-registry }
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/arch"]
+          value: amd64
+      - equal:
+          path: spec.template.spec.nodeSelector["topology.kubernetes.io/zone"]
+          value: us-east-1a
+      - lengthEqual: { path: "spec.template.spec.tolerations", count: 2 }
+      - equal: { path: "spec.template.spec.tolerations[0].key", value: first-taint }
+      - equal: { path: "spec.template.spec.tolerations[1].key", value: second-taint }
+      - equal:
+          path: "spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[1]"
+          value: windows
+      - equal:
+          path: spec.template.metadata.labels["first-label"]
+          value: one
+      - equal:
+          path: spec.template.metadata.labels["second-label"]
+          value: two
+      - equal:
+          path: spec.template.metadata.annotations["first-annotation"]
+          value: one
+      - equal:
+          path: spec.template.metadata.annotations["second-annotation"]
+          value: two
+      - contains:
+          path: spec.template.spec.volumes
+          content: { name: first-extra, emptyDir: {} }
+      - contains:
+          path: spec.template.spec.volumes
+          content: { name: second-extra, emptyDir: {} }
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: { name: first-extra, mountPath: /first }
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: { name: second-extra, mountPath: /second }

--- a/charts/pihole-exporter/tests/service_test.yaml
+++ b/charts/pihole-exporter/tests/service_test.yaml
@@ -1,0 +1,65 @@
+suite: pihole-exporter Service
+templates:
+  - templates/service.yaml
+release:
+  name: rel
+tests:
+  - it: renders one Service named for the chart fullname
+    asserts:
+      - hasDocuments: { count: 1 }
+      - isKind: { of: Service }
+      - equal: { path: metadata.name, value: rel-pihole-exporter }
+
+  # Pins the shipped defaults: the port and its name are what a ServiceMonitor
+  # and the container port agree on, so a silent change here breaks scraping
+  # without breaking any render.
+  - it: wires port, targetPort, protocol and name from values
+    asserts:
+      - equal: { path: "spec.ports[0].port", value: 9617 }
+      - equal: { path: "spec.ports[0].targetPort", value: 9617 }
+      - equal: { path: "spec.ports[0].protocol", value: TCP }
+      - equal: { path: "spec.ports[0].name", value: metrics }
+      - equal: { path: spec.type, value: ClusterIP }
+
+  - it: honours the service value overrides
+    set:
+      service.type: LoadBalancer
+      service.port: 18080
+      service.protocol: UDP
+      service.name: custom
+    asserts:
+      - equal: { path: spec.type, value: LoadBalancer }
+      - equal: { path: "spec.ports[0].port", value: 18080 }
+      - equal: { path: "spec.ports[0].targetPort", value: 18080 }
+      - equal: { path: "spec.ports[0].protocol", value: UDP }
+      - equal: { path: "spec.ports[0].name", value: custom }
+
+  # The selector must stay the `selectorLabels` subset. Swapping it for the full
+  # `labels` helper bakes helm.sh/chart and app.kubernetes.io/version into the
+  # selector, which then changes on every chart bump - the Service silently
+  # stops matching any pod whose template labels were rendered by an older
+  # revision. Both halves are asserted: the two keys that belong, and the three
+  # that must not appear.
+  - it: selects on the selector-label subset only
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: pihole-exporter
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: rel
+      - notExists:
+          path: spec.selector["helm.sh/chart"]
+      - notExists:
+          path: spec.selector["app.kubernetes.io/version"]
+      - notExists:
+          path: spec.selector["app.kubernetes.io/managed-by"]
+
+  # metadata.labels is the opposite case - it carries the full set.
+  - it: carries the full label set on metadata
+    asserts:
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm

--- a/charts/qbittorrent-exporter/tests/deployment_test.yaml
+++ b/charts/qbittorrent-exporter/tests/deployment_test.yaml
@@ -128,3 +128,111 @@ tests:
     asserts:
       - exists: { path: spec.template.spec.serviceAccountName }
       - equal: { path: spec.template.spec.automountServiceAccountToken, value: false }
+
+  # Optional pod-spec blocks. Static validation cannot see these: a pod spec
+  # missing imagePullSecrets is schema-valid, so only a unit test catches a
+  # `with` block that stopped rendering. Both directions are pinned - absent
+  # when unset, and every entry present when set.
+  - it: omits every optional pod-spec block when unset
+    asserts:
+      - notExists: { path: spec.template.spec.imagePullSecrets }
+      - notExists: { path: spec.template.spec.nodeSelector }
+      - notExists: { path: spec.template.spec.affinity }
+      - notExists: { path: spec.template.spec.tolerations }
+      - notExists: { path: spec.template.spec.volumes }
+      - notExists: { path: "spec.template.spec.containers[0].volumeMounts" }
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  # updateStrategy is a `with` block with a NON-empty default, so losing it
+  # does not omit a feature - it silently flips the workload to RollingUpdate.
+  - it: keeps the Recreate update strategy by default
+    asserts:
+      - equal: { path: spec.strategy.type, value: Recreate }
+
+  # Two entries per list on purpose: one entry cannot catch a range that only
+  # ever emits its first item, and two map keys catch a `toYaml` swapped for a
+  # single-key interpolation. Lengths are pinned too, so a spurious third entry
+  # fails rather than passing on the two that were checked.
+  - it: renders every entry of every optional pod-spec block when set
+    set:
+      imagePullSecrets:
+        - name: first-registry
+        - name: second-registry
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        topology.kubernetes.io/zone: us-east-1a
+      tolerations:
+        - key: first-taint
+          operator: Exists
+          effect: NoSchedule
+        - key: second-taint
+          operator: Exists
+          effect: NoExecute
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                      - windows
+      podLabels:
+        first-label: one
+        second-label: two
+      podAnnotations:
+        first-annotation: one
+        second-annotation: two
+      volumes:
+        - name: first-extra
+          emptyDir: {}
+        - name: second-extra
+          emptyDir: {}
+      volumeMounts:
+        - name: first-extra
+          mountPath: /first
+        - name: second-extra
+          mountPath: /second
+    asserts:
+      - lengthEqual: { path: "spec.template.spec.imagePullSecrets", count: 2 }
+      - equal: { path: "spec.template.spec.imagePullSecrets[0].name", value: first-registry }
+      - equal: { path: "spec.template.spec.imagePullSecrets[1].name", value: second-registry }
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/arch"]
+          value: amd64
+      - equal:
+          path: spec.template.spec.nodeSelector["topology.kubernetes.io/zone"]
+          value: us-east-1a
+      - lengthEqual: { path: "spec.template.spec.tolerations", count: 2 }
+      - equal: { path: "spec.template.spec.tolerations[0].key", value: first-taint }
+      - equal: { path: "spec.template.spec.tolerations[1].key", value: second-taint }
+      - equal:
+          path: "spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[1]"
+          value: windows
+      - equal:
+          path: spec.template.metadata.labels["first-label"]
+          value: one
+      - equal:
+          path: spec.template.metadata.labels["second-label"]
+          value: two
+      - equal:
+          path: spec.template.metadata.annotations["first-annotation"]
+          value: one
+      - equal:
+          path: spec.template.metadata.annotations["second-annotation"]
+          value: two
+      - contains:
+          path: spec.template.spec.volumes
+          content: { name: first-extra, emptyDir: {} }
+      - contains:
+          path: spec.template.spec.volumes
+          content: { name: second-extra, emptyDir: {} }
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: { name: first-extra, mountPath: /first }
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: { name: second-extra, mountPath: /second }

--- a/charts/qbittorrent-exporter/tests/service_test.yaml
+++ b/charts/qbittorrent-exporter/tests/service_test.yaml
@@ -1,0 +1,65 @@
+suite: qbittorrent-exporter Service
+templates:
+  - templates/service.yaml
+release:
+  name: rel
+tests:
+  - it: renders one Service named for the chart fullname
+    asserts:
+      - hasDocuments: { count: 1 }
+      - isKind: { of: Service }
+      - equal: { path: metadata.name, value: rel-qbittorrent-exporter }
+
+  # Pins the shipped defaults: the port and its name are what a ServiceMonitor
+  # and the container port agree on, so a silent change here breaks scraping
+  # without breaking any render.
+  - it: wires port, targetPort, protocol and name from values
+    asserts:
+      - equal: { path: "spec.ports[0].port", value: 8090 }
+      - equal: { path: "spec.ports[0].targetPort", value: 8090 }
+      - equal: { path: "spec.ports[0].protocol", value: TCP }
+      - equal: { path: "spec.ports[0].name", value: metrics }
+      - equal: { path: spec.type, value: ClusterIP }
+
+  - it: honours the service value overrides
+    set:
+      service.type: LoadBalancer
+      service.port: 18080
+      service.protocol: UDP
+      service.name: custom
+    asserts:
+      - equal: { path: spec.type, value: LoadBalancer }
+      - equal: { path: "spec.ports[0].port", value: 18080 }
+      - equal: { path: "spec.ports[0].targetPort", value: 18080 }
+      - equal: { path: "spec.ports[0].protocol", value: UDP }
+      - equal: { path: "spec.ports[0].name", value: custom }
+
+  # The selector must stay the `selectorLabels` subset. Swapping it for the full
+  # `labels` helper bakes helm.sh/chart and app.kubernetes.io/version into the
+  # selector, which then changes on every chart bump - the Service silently
+  # stops matching any pod whose template labels were rendered by an older
+  # revision. Both halves are asserted: the two keys that belong, and the three
+  # that must not appear.
+  - it: selects on the selector-label subset only
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: qbittorrent-exporter
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: rel
+      - notExists:
+          path: spec.selector["helm.sh/chart"]
+      - notExists:
+          path: spec.selector["app.kubernetes.io/version"]
+      - notExists:
+          path: spec.selector["app.kubernetes.io/managed-by"]
+
+  # metadata.labels is the opposite case - it carries the full set.
+  - it: carries the full label set on metadata
+    asserts:
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm

--- a/charts/tdarr-exporter/tests/deployment_test.yaml
+++ b/charts/tdarr-exporter/tests/deployment_test.yaml
@@ -105,3 +105,111 @@ tests:
     asserts:
       - exists: { path: spec.template.spec.serviceAccountName }
       - equal: { path: spec.template.spec.automountServiceAccountToken, value: false }
+
+  # Optional pod-spec blocks. Static validation cannot see these: a pod spec
+  # missing imagePullSecrets is schema-valid, so only a unit test catches a
+  # `with` block that stopped rendering. Both directions are pinned - absent
+  # when unset, and every entry present when set.
+  - it: omits every optional pod-spec block when unset
+    asserts:
+      - notExists: { path: spec.template.spec.imagePullSecrets }
+      - notExists: { path: spec.template.spec.nodeSelector }
+      - notExists: { path: spec.template.spec.affinity }
+      - notExists: { path: spec.template.spec.tolerations }
+      - notExists: { path: spec.template.spec.volumes }
+      - notExists: { path: "spec.template.spec.containers[0].volumeMounts" }
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  # updateStrategy is a `with` block with a NON-empty default, so losing it
+  # does not omit a feature - it silently flips the workload to RollingUpdate.
+  - it: keeps the Recreate update strategy by default
+    asserts:
+      - equal: { path: spec.strategy.type, value: Recreate }
+
+  # Two entries per list on purpose: one entry cannot catch a range that only
+  # ever emits its first item, and two map keys catch a `toYaml` swapped for a
+  # single-key interpolation. Lengths are pinned too, so a spurious third entry
+  # fails rather than passing on the two that were checked.
+  - it: renders every entry of every optional pod-spec block when set
+    set:
+      imagePullSecrets:
+        - name: first-registry
+        - name: second-registry
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        topology.kubernetes.io/zone: us-east-1a
+      tolerations:
+        - key: first-taint
+          operator: Exists
+          effect: NoSchedule
+        - key: second-taint
+          operator: Exists
+          effect: NoExecute
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                      - windows
+      podLabels:
+        first-label: one
+        second-label: two
+      podAnnotations:
+        first-annotation: one
+        second-annotation: two
+      volumes:
+        - name: first-extra
+          emptyDir: {}
+        - name: second-extra
+          emptyDir: {}
+      volumeMounts:
+        - name: first-extra
+          mountPath: /first
+        - name: second-extra
+          mountPath: /second
+    asserts:
+      - lengthEqual: { path: "spec.template.spec.imagePullSecrets", count: 2 }
+      - equal: { path: "spec.template.spec.imagePullSecrets[0].name", value: first-registry }
+      - equal: { path: "spec.template.spec.imagePullSecrets[1].name", value: second-registry }
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/arch"]
+          value: amd64
+      - equal:
+          path: spec.template.spec.nodeSelector["topology.kubernetes.io/zone"]
+          value: us-east-1a
+      - lengthEqual: { path: "spec.template.spec.tolerations", count: 2 }
+      - equal: { path: "spec.template.spec.tolerations[0].key", value: first-taint }
+      - equal: { path: "spec.template.spec.tolerations[1].key", value: second-taint }
+      - equal:
+          path: "spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[1]"
+          value: windows
+      - equal:
+          path: spec.template.metadata.labels["first-label"]
+          value: one
+      - equal:
+          path: spec.template.metadata.labels["second-label"]
+          value: two
+      - equal:
+          path: spec.template.metadata.annotations["first-annotation"]
+          value: one
+      - equal:
+          path: spec.template.metadata.annotations["second-annotation"]
+          value: two
+      - contains:
+          path: spec.template.spec.volumes
+          content: { name: first-extra, emptyDir: {} }
+      - contains:
+          path: spec.template.spec.volumes
+          content: { name: second-extra, emptyDir: {} }
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: { name: first-extra, mountPath: /first }
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: { name: second-extra, mountPath: /second }

--- a/charts/tdarr-exporter/tests/service_test.yaml
+++ b/charts/tdarr-exporter/tests/service_test.yaml
@@ -1,0 +1,65 @@
+suite: tdarr-exporter Service
+templates:
+  - templates/service.yaml
+release:
+  name: rel
+tests:
+  - it: renders one Service named for the chart fullname
+    asserts:
+      - hasDocuments: { count: 1 }
+      - isKind: { of: Service }
+      - equal: { path: metadata.name, value: rel-tdarr-exporter }
+
+  # Pins the shipped defaults: the port and its name are what a ServiceMonitor
+  # and the container port agree on, so a silent change here breaks scraping
+  # without breaking any render.
+  - it: wires port, targetPort, protocol and name from values
+    asserts:
+      - equal: { path: "spec.ports[0].port", value: 9090 }
+      - equal: { path: "spec.ports[0].targetPort", value: 9090 }
+      - equal: { path: "spec.ports[0].protocol", value: TCP }
+      - equal: { path: "spec.ports[0].name", value: metrics }
+      - equal: { path: spec.type, value: ClusterIP }
+
+  - it: honours the service value overrides
+    set:
+      service.type: LoadBalancer
+      service.port: 18080
+      service.protocol: UDP
+      service.name: custom
+    asserts:
+      - equal: { path: spec.type, value: LoadBalancer }
+      - equal: { path: "spec.ports[0].port", value: 18080 }
+      - equal: { path: "spec.ports[0].targetPort", value: 18080 }
+      - equal: { path: "spec.ports[0].protocol", value: UDP }
+      - equal: { path: "spec.ports[0].name", value: custom }
+
+  # The selector must stay the `selectorLabels` subset. Swapping it for the full
+  # `labels` helper bakes helm.sh/chart and app.kubernetes.io/version into the
+  # selector, which then changes on every chart bump - the Service silently
+  # stops matching any pod whose template labels were rendered by an older
+  # revision. Both halves are asserted: the two keys that belong, and the three
+  # that must not appear.
+  - it: selects on the selector-label subset only
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: tdarr-exporter
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: rel
+      - notExists:
+          path: spec.selector["helm.sh/chart"]
+      - notExists:
+          path: spec.selector["app.kubernetes.io/version"]
+      - notExists:
+          path: spec.selector["app.kubernetes.io/managed-by"]
+
+  # metadata.labels is the opposite case - it carries the full set.
+  - it: carries the full label set on metadata
+    asserts:
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm

--- a/charts/unpoller/tests/deployment_test.yaml
+++ b/charts/unpoller/tests/deployment_test.yaml
@@ -165,3 +165,87 @@ tests:
     asserts:
       - exists: { path: spec.template.spec.serviceAccountName }
       - equal: { path: spec.template.spec.automountServiceAccountToken, value: false }
+
+  # Optional pod-spec blocks. Static validation cannot see these: a pod spec
+  # missing imagePullSecrets is schema-valid, so only a unit test catches a
+  # `with` block that stopped rendering. Both directions are pinned - absent
+  # when unset, and every entry present when set.
+  - it: omits every optional pod-spec block when unset
+    asserts:
+      - notExists: { path: spec.template.spec.imagePullSecrets }
+      - notExists: { path: spec.template.spec.nodeSelector }
+      - notExists: { path: spec.template.spec.affinity }
+      - notExists: { path: spec.template.spec.tolerations }
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  # updateStrategy is a `with` block with a NON-empty default, so losing it
+  # does not omit a feature - it silently flips the workload to RollingUpdate.
+  - it: keeps the Recreate update strategy by default
+    asserts:
+      - equal: { path: spec.strategy.type, value: Recreate }
+
+  # Two entries per list on purpose: one entry cannot catch a range that only
+  # ever emits its first item, and two map keys catch a `toYaml` swapped for a
+  # single-key interpolation. Lengths are pinned too, so a spurious third entry
+  # fails rather than passing on the two that were checked.
+  - it: renders every entry of every optional pod-spec block when set
+    set:
+      imagePullSecrets:
+        - name: first-registry
+        - name: second-registry
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        topology.kubernetes.io/zone: us-east-1a
+      tolerations:
+        - key: first-taint
+          operator: Exists
+          effect: NoSchedule
+        - key: second-taint
+          operator: Exists
+          effect: NoExecute
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                      - windows
+      podLabels:
+        first-label: one
+        second-label: two
+      podAnnotations:
+        first-annotation: one
+        second-annotation: two
+    asserts:
+      - lengthEqual: { path: "spec.template.spec.imagePullSecrets", count: 2 }
+      - equal: { path: "spec.template.spec.imagePullSecrets[0].name", value: first-registry }
+      - equal: { path: "spec.template.spec.imagePullSecrets[1].name", value: second-registry }
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/arch"]
+          value: amd64
+      - equal:
+          path: spec.template.spec.nodeSelector["topology.kubernetes.io/zone"]
+          value: us-east-1a
+      - lengthEqual: { path: "spec.template.spec.tolerations", count: 2 }
+      - equal: { path: "spec.template.spec.tolerations[0].key", value: first-taint }
+      - equal: { path: "spec.template.spec.tolerations[1].key", value: second-taint }
+      - equal:
+          path: "spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[1]"
+          value: windows
+      - equal:
+          path: spec.template.metadata.labels["first-label"]
+          value: one
+      - equal:
+          path: spec.template.metadata.labels["second-label"]
+          value: two
+      - equal:
+          path: spec.template.metadata.annotations["first-annotation"]
+          value: one
+      - equal:
+          path: spec.template.metadata.annotations["second-annotation"]
+          value: two

--- a/charts/unpoller/tests/service_test.yaml
+++ b/charts/unpoller/tests/service_test.yaml
@@ -1,0 +1,65 @@
+suite: unpoller Service
+templates:
+  - templates/service.yaml
+release:
+  name: rel
+tests:
+  - it: renders one Service named for the chart fullname
+    asserts:
+      - hasDocuments: { count: 1 }
+      - isKind: { of: Service }
+      - equal: { path: metadata.name, value: rel-unpoller }
+
+  # Pins the shipped defaults: the port and its name are what a ServiceMonitor
+  # and the container port agree on, so a silent change here breaks scraping
+  # without breaking any render.
+  - it: wires port, targetPort, protocol and name from values
+    asserts:
+      - equal: { path: "spec.ports[0].port", value: 9130 }
+      - equal: { path: "spec.ports[0].targetPort", value: 9130 }
+      - equal: { path: "spec.ports[0].protocol", value: TCP }
+      - equal: { path: "spec.ports[0].name", value: metrics }
+      - equal: { path: spec.type, value: ClusterIP }
+
+  - it: honours the service value overrides
+    set:
+      service.type: LoadBalancer
+      service.port: 18080
+      service.protocol: UDP
+      service.name: custom
+    asserts:
+      - equal: { path: spec.type, value: LoadBalancer }
+      - equal: { path: "spec.ports[0].port", value: 18080 }
+      - equal: { path: "spec.ports[0].targetPort", value: 18080 }
+      - equal: { path: "spec.ports[0].protocol", value: UDP }
+      - equal: { path: "spec.ports[0].name", value: custom }
+
+  # The selector must stay the `selectorLabels` subset. Swapping it for the full
+  # `labels` helper bakes helm.sh/chart and app.kubernetes.io/version into the
+  # selector, which then changes on every chart bump - the Service silently
+  # stops matching any pod whose template labels were rendered by an older
+  # revision. Both halves are asserted: the two keys that belong, and the three
+  # that must not appear.
+  - it: selects on the selector-label subset only
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: unpoller
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: rel
+      - notExists:
+          path: spec.selector["helm.sh/chart"]
+      - notExists:
+          path: spec.selector["app.kubernetes.io/version"]
+      - notExists:
+          path: spec.selector["app.kubernetes.io/managed-by"]
+
+  # metadata.labels is the opposite case - it carries the full set.
+  - it: carries the full label set on metadata
+    asserts:
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm

--- a/charts/v-rising/tests/deployment_test.yaml
+++ b/charts/v-rising/tests/deployment_test.yaml
@@ -135,3 +135,101 @@ tests:
     asserts:
       - exists: { path: spec.template.spec.serviceAccountName }
       - equal: { path: spec.template.spec.automountServiceAccountToken, value: false }
+
+  # Optional pod-spec blocks. Static validation cannot see these: a pod spec
+  # missing imagePullSecrets is schema-valid, so only a unit test catches a
+  # `with` block that stopped rendering. Both directions are pinned - absent
+  # when unset, and every entry present when set.
+  - it: omits every optional pod-spec block when unset
+    asserts:
+      - notExists: { path: spec.template.spec.imagePullSecrets }
+      - notExists: { path: spec.template.spec.nodeSelector }
+      - notExists: { path: spec.template.spec.affinity }
+      - notExists: { path: spec.template.spec.tolerations }
+      - notExists: { path: spec.template.metadata.annotations }
+
+  # Two entries per list on purpose: one entry cannot catch a range that only
+  # ever emits its first item, and two map keys catch a `toYaml` swapped for a
+  # single-key interpolation. Lengths are pinned too, so a spurious third entry
+  # fails rather than passing on the two that were checked.
+  - it: renders every entry of every optional pod-spec block when set
+    set:
+      imagePullSecrets:
+        - name: first-registry
+        - name: second-registry
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        topology.kubernetes.io/zone: us-east-1a
+      tolerations:
+        - key: first-taint
+          operator: Exists
+          effect: NoSchedule
+        - key: second-taint
+          operator: Exists
+          effect: NoExecute
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+                      - windows
+      podLabels:
+        first-label: one
+        second-label: two
+      podAnnotations:
+        first-annotation: one
+        second-annotation: two
+      volumes:
+        - name: first-extra
+          emptyDir: {}
+        - name: second-extra
+          emptyDir: {}
+      volumeMounts:
+        - name: first-extra
+          mountPath: /first
+        - name: second-extra
+          mountPath: /second
+    asserts:
+      - lengthEqual: { path: "spec.template.spec.imagePullSecrets", count: 2 }
+      - equal: { path: "spec.template.spec.imagePullSecrets[0].name", value: first-registry }
+      - equal: { path: "spec.template.spec.imagePullSecrets[1].name", value: second-registry }
+      - equal:
+          path: spec.template.spec.nodeSelector["kubernetes.io/arch"]
+          value: amd64
+      - equal:
+          path: spec.template.spec.nodeSelector["topology.kubernetes.io/zone"]
+          value: us-east-1a
+      - lengthEqual: { path: "spec.template.spec.tolerations", count: 2 }
+      - equal: { path: "spec.template.spec.tolerations[0].key", value: first-taint }
+      - equal: { path: "spec.template.spec.tolerations[1].key", value: second-taint }
+      - equal:
+          path: "spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[1]"
+          value: windows
+      - equal:
+          path: spec.template.metadata.labels["first-label"]
+          value: one
+      - equal:
+          path: spec.template.metadata.labels["second-label"]
+          value: two
+      - equal:
+          path: spec.template.metadata.annotations["first-annotation"]
+          value: one
+      - equal:
+          path: spec.template.metadata.annotations["second-annotation"]
+          value: two
+      - contains:
+          path: spec.template.spec.volumes
+          content: { name: first-extra, emptyDir: {} }
+      - contains:
+          path: spec.template.spec.volumes
+          content: { name: second-extra, emptyDir: {} }
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: { name: first-extra, mountPath: /first }
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content: { name: second-extra, mountPath: /second }


### PR DESCRIPTION
Last of three PRs closing the fleet-wide unit-test omission gap. #175 took `ingress.yaml`, #176 took `serviceaccount.yaml`; this takes `service.yaml` and the pod-spec passthroughs.

Test-only. **No chart versions bumped and nothing is published** — `ct` cannot see `charts/*/tests/**` (`use-helmignore: true`), while `ci-tooling.yml`'s path filter does run the unit suites fleet-wide, so CI gates this even though no chart is "changed".

## Changes

**Pod-spec omission coverage, all 8 charts that ship a pod spec.** Static analysis cannot catch a missing optional field — a pod spec without `imagePullSecrets` is schema-valid, so nothing distinguishes a `with` block that stopped rendering from one that was never configured. Before this, `imagePullSecrets` appeared in exactly one test file against ten templates, and `nodeSelector`, `tolerations`, `affinity`, `podLabels`, `podAnnotations` and `volumeMounts` appeared in none.

Each suite now pins both directions: absent when unset, every entry present when set. Payloads carry two entries per list and two keys per map — one entry cannot catch a range that only ever emits its first item — and lengths are pinned, so a spurious third entry fails rather than passing on the two that were checked. Volumes are asserted with `contains` rather than by index, because several charts already render volumes by default.

`updateStrategy` is included as the inverted case: it is a `with` block with a **non-empty** default, so losing it does not omit a feature — it silently flips the workload to `RollingUpdate` and deadlocks a rollout against an RWO PVC.

**Six new `service_test.yaml`.** Five of the six templates are static shapes with no conditionals, so rather than pad them the suites target the one reachable defect class: the selector must stay the `selectorLabels` subset. Swapping it for the full `labels` helper bakes `helm.sh/chart` and `app.kubernetes.io/version` into the selector, which then changes on every chart bump. Both halves are pinned — the two keys that belong and the three that must not appear. `exportarr` additionally covers per-instance naming and the component label on all three sites that carry it; `bookstack` covers its named `targetPort`.

## Motivation

This is the defect class that shipped the bugs #176 fixed. `serviceAccount.automount` was wired only into the ServiceAccount object and was inert on the pod spec; the PrometheusRule was ungated on `metrics.enabled`. Both rendered valid YAML, both passed every static tier, and the unit suites asserted what the templates *emit* while never asserting that a disabled feature emits *nothing*.

## Test plan

- `task verify APP=<chart>` — **PASS on all 9**, including the untouched `nut-exporter`. 480 fleet tests.
- **Mutation-verified on scratch copies outside the working tree, baselines clean.** Each of these fails a named case: dropping the `imagePullSecrets`, `podLabels`, `podAnnotations`, `metrics.podAnnotations`, `updateStrategy` and volume/volumeMount blocks; emitting only the first toleration; removing the `nodeSelector` guard; swapping `selectorLabels` for `labels`; hardcoding the port name; decoupling `targetPort` from `service.port`; dropping exportarr's component label from the pod template, from `spec.selector.matchLabels` and from the Service selector; collapsing exportarr's name to omit the apps map key; and deleting all four of its volume passthroughs.
- A later review pass found two dead asserts in the exportarr two-instance Service case: `exists` on `metadata.name` paired with a `documentSelector` on that same path, which cannot fail independently of the selection. Each selected document now asserts its own selector-side component label instead, and deleting that label from the Service selector fails the case where the previous form passed.

## In-depth

**The absent-key list is per chart, not fleet-wide.** `volumes` is non-empty by default in `bookstack`, `v-rising` and `bookstack-file-exporter`, so asserting its absence there would have pinned a falsehood. `exportarr` is excluded for the opposite reason: it emits `volumes:` unguarded with the `with` blocks nested inside, so the key is always present with a null value, and helm-unittest treats a null-valued key as existing. Pod annotations split the same way — absent by default in three charts, carrying the `prometheus.io` scrape set in the other five, where the useful assertion is that those annotations are still *there*.

**One mutation initially escaped.** Unquoting bookstack's `targetPort` renders identically for the default `portName: http`, because bare `http` is already a string — the test was fine, the mutation was toothless. Added the digits-only case the quoting actually guards. A digits-only name is not a legal `IANA_SVC_NAME`, so that case is a type-stability guard rather than a reachable bug, and the comment says so.

**Reviewed before opening.** Two independent read-only passes, one on helm-unittest/Helm idiom and one on whether the assertions have teeth. The second found five gaps in the first draft, each proven by a mutation the draft did not catch — the exportarr component label on the Deployment side, exportarr's four volume passthroughs, `volumes`/`volumeMounts` in v-rising and bookstack-file-exporter, `podAnnotations` fleet-wide, and `updateStrategy`. All are folded in above. The first pass contributed `lengthEqual` on the populated lists (matching the repo's existing ingress suites), `documentSelector` in place of ordinal `documentIndex`, `isType`, and removal of duplicated `imagePullSecrets` coverage in bookstack-file-exporter.

## Not addressed here

**`exportarr` overflows the 63-character limit on names and label values.** `$appName` concatenates an already-`trunc 63` fullname with the apps map key and the instance name and is used as both `metadata.name` and the `app.kubernetes.io/component` label value, with no re-truncation. Verified: a 42-character release name plus `main` already yields 64 characters, and a realistic long pair renders 97 for the Service name, the Deployment name and the label value. `kubeconform` reports `Valid: 3, Invalid: 0` on that render, so the static gate cannot see it — only an install fails. Left out because the fix changes rendered resource names and needs a version bump plus an upgrade-matrix row.

Also unchanged: `app.kubernetes.io/component` carrying a per-instance unique name rather than an architectural role (pre-existing, already pinned by `servicemonitor_test.yaml`), and `nut-exporter`, which has no suites and stays deprecated.

