### PR TITLE
ci: run the static tier on every PR so it can be required

### DIFF
--- a/.github/workflows/ci-tooling.yml
+++ b/.github/workflows/ci-tooling.yml
@@ -6,31 +6,21 @@ permissions: {}
 # is no help either — with no changed charts it prints "All charts linted successfully"
 # and exits 0 on zero work. A typo in kubeconform.sh would merge green.
 #
-# So: run the tier against the whole fleet whenever the tier changes, or when one of the
-# chart-side inputs `ct` cannot see changes — the helmignored ci/ overlays and tests/
-# suites below. Chart PRs usually touch templates/ and tests/ together, so this now fires
-# alongside ci.yml on most of them; that is fine, it is cluster-free and takes seconds.
-# Path filters are workflow-level in Actions, which is why this is a separate file rather
-# than a job in ci.yml.
+# The same blind spot covers the chart-side inputs `ct` cannot see: the helmignored
+# `ci/` overlays and `tests/` suites. On a PR that touches only those, ci.yml's job is
+# the one that does no work, and this one runs every unit suite in the fleet.
 #
-# Not a required status check: a path-filtered check never reports on PRs that miss the
-# filter, so branch protection would block forever waiting on it.
+# Runs on every PR, deliberately unfiltered, because this is a required status check.
+# A path-filtered check can never be required: PRs that miss the filter never report it,
+# so the merge blocks forever waiting on a status that will not arrive. Running it
+# unconditionally costs seconds — it is cluster-free and only renders nine charts.
+#
+# Kept as its own workflow rather than a job in ci.yml so it reports under its own
+# status name and is not queued behind ci.yml's kind cluster.
 on:
   pull_request:
     branches:
       - main
-    paths:
-      - scripts/ci/**
-      # Per-chart kubeconform overlays. They live in each chart's helmignored
-      # ci/ dir, so `ct list-changed` never sees them and ci.yml skips - this
-      # workflow is their only gate.
-      - charts/*/ci/kubeconform-overlay.yaml
-      # helm-unittest suites, for the same reason: `/tests/` is helmignored in
-      # every chart, so a PR that only adds or edits a suite drops the chart out
-      # of `ct list-changed` and the new tests would run nowhere.
-      - charts/*/tests/**
-      - .github/ct/**
-      - .github/workflows/ci-tooling.yml
 
 concurrency:
   group: ci-tooling-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Makes the fleet-wide static tier eligible to be a required status check, which is the
step that turns the last three test-coverage PRs (#175, #176, #178) from advisory into
enforced.

## Changes

`.github/workflows/ci-tooling.yml` drops its `paths:` filter and now runs on every PR to
`main`. Header comment rewritten to match — it previously argued the opposite position.

No chart is touched, no version bumps, nothing publishes.

**This PR is half the fix.** The other half is a repo-settings change only a maintainer
can make: add these two to `main`'s required status checks.

- `Validate the static tier against every chart` — this PR is its precondition
- `Lint workflow files` — already eligible today, `actionlint.yml` has always been
  unfiltered for exactly this reason

## Motivation

`main`'s protection required exactly one context:

```
$ gh api repos/homeylab/helm-charts/branches/main/protection
required_contexts: ["Lint and unit-test changed charts"]
```

On a PR that touches only `charts/*/tests/**`, that job is the one that does no work.
`use-helmignore: true` plus the anchored `/tests/` in every `.helmignore` drops the chart
out of `ct list-changed`, and `ct lint` on zero charts prints "All charts linted
successfully" and exits 0. The job that actually ran the 480 unit suites — `Validate the
static tier against every chart` — was advisory.

So a PR that broke the fleet's unit tests would show a green required check next to a red
advisory one, and would be mergeable. #178 was precisely that shape: 1367 lines of new
test coverage, gated only by a check that was configured not to see it.

The `paths:` filter is what made it ineligible. A path-filtered check never reports on a
PR that misses the filter, so branch protection blocks forever on a status that will not
arrive — the workflow's own header documented this as the reason it could not be
required. Removing the filter is therefore the precondition, not an optimization.

## Test plan

- Trigger verified after the edit — no `paths:` key survives:
  ```
  $ python3 -c "import yaml; print(yaml.safe_load(open('.github/workflows/ci-tooling.yml'))[True]['pull_request'])"
  {'branches': ['main']}
  ```
- Not self-proving: `.github/workflows/ci-tooling.yml` was itself in the old `paths:`
  list, so this PR would have triggered the workflow under either config. The change is
  observable on the next PR that touches only a chart template, `Chart.yaml`, or a README
  — paths the old filter did not match, where `CI tooling` previously did not run at all.
- `actionlint` gates the workflow syntax; it is not installed locally.

## In-depth

**Cost.** The tier is cluster-free: nine charts through helm-unittest and two kubeconform
passes each, in seconds. It already fired alongside `ci.yml` on most chart PRs, since
chart work usually touches `templates/` and `tests/` together. The added surface is
docs-only and workflow-only PRs.

**Why not fold it into `ci.yml`.** Kept separate so it reports under its own status name
— required checks are matched by name, and a merged job would put the fleet-wide tier
behind the kind-cluster install in the same status. Path filters being workflow-level was
the original reason for the split; that reason is gone, but the naming one stands on its
own.

**What this does not fix.** `ci/*-values.yaml` is still read by nothing in CI — it feeds
`ct install`, which does not run on a test-only PR. It remains verified only by
`task test APP=<chart>` locally.
