### PR TITLE
ci: skip OCI pushes for chart versions already published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,15 @@ jobs:
           CR_SKIP_EXISTING: true # https://github.com/helm/chart-releaser-action/issues/97
           CR_GENERATE_RELEASE_NOTES: true
 
-      # chart-releaser leaves the charts it just released (changed versions only,
-      # deps vendored) in .cr-release-packages/. Push those same packages to OCI so
-      # (a) OCI publishes only what Pages did, and (b) a failed release blocks the
-      # push — no channel desync. Mirrors the prometheus-community pattern.
-      - name: Detect released charts
-        id: released
+      # chart-releaser packages every chart whose files changed since
+      # `git describe --tags --abbrev=0 HEAD~`. That assumes one linear release
+      # tag; with per-chart tags the base is whichever tag describe happens to
+      # pick, so .cr-release-packages/ can hold far more than was just released.
+      # CR_SKIP_EXISTING gates only the Pages upload, and `helm package` is not
+      # reproducible across checkouts (file mtimes land in the tarball), so an
+      # unguarded push moves published tags to new digests. Hence the probe below.
+      - name: Detect packaged charts
+        id: packaged
         run: |
           shopt -s nullglob
           pkgs=(.cr-release-packages/*.tgz)
@@ -63,17 +66,45 @@ jobs:
       # Log in / push only when there's something to publish, so doc- or
       # workflow-only merges never touch Docker Hub.
       - name: Helm Registry Login
-        if: steps.released.outputs.has == 'true'
+        if: steps.packaged.outputs.has == 'true'
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: echo "$DOCKERHUB_TOKEN" | helm registry login registry-1.docker.io -u "$DOCKERHUB_USERNAME" --password-stdin
 
-      - name: Push released charts to OCI
-        if: steps.released.outputs.has == 'true'
+      - name: Push packaged charts to OCI
+        if: steps.packaged.outputs.has == 'true'
         run: |
           shopt -s nullglob
           for pkg in .cr-release-packages/*.tgz; do
-            echo "Pushing $pkg"
+            # Anchor the match to column 1: `helm package` sorts Chart.yaml keys,
+            # so `annotations:` and `dependencies:` both precede `name:`, and both
+            # carry their own indented name:/version: entries. Unanchored, an
+            # umbrella resolves to a dependency (bookstack -> mariadb).
+            top=$(tar -tzf "$pkg" | awk -F/ 'NF==2 && $2=="Chart.yaml"{print; exit}')
+            meta=$(tar -xzOf "$pkg" "$top")
+            name=$(awk '/^name:/{print $2; exit}' <<< "$meta")
+            version=$(awk '/^version:/{print $2; exit}' <<< "$meta")
+            if [ -z "$name" ] || [ -z "$version" ]; then
+              echo "::error::Could not read name/version from ${pkg}"
+              exit 1
+            fi
+            repo="registry-1.docker.io/homeylabcharts/${name}"
+
+            # Three states, not two: only a definite "not found" means absent. An
+            # auth, DNS or 5xx failure must fail the job rather than fall through
+            # to a push, which would re-push exactly when the registry is flaky.
+            if output=$(helm show chart "oci://${repo}" --version "$version" 2>&1); then
+              echo "::notice::Skipping ${name} ${version}: already published"
+              continue
+            elif grep -q "not found" <<< "$output"; then
+              : # absent - fall through and push
+            else
+              echo "::error::Cannot verify ${name} ${version}; refusing to push blind"
+              echo "$output"
+              exit 1
+            fi
+
+            echo "Pushing ${name} ${version}"
             helm push "$pkg" oci://registry-1.docker.io/homeylabcharts
           done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,12 +197,14 @@ Pipeline:
 
 1. **Renovate** (CI) bumps `appVersion` when the upstream image releases, then bumps the chart `version` (upstream patch → chart patch; minor/major → chart minor), scoped so only the changed chart bumps. (The `helm-values` manager is disabled — image versions are tracked *only* via `appVersion`, never `values.yaml`.)
 2. On **merge to `main`**, the single `release` job in [`release.yml`](.github/workflows/release.yml) runs:
-   - **`chart-releaser`** publishes any chart whose `Chart.yaml` `version` changed to the GitHub Pages Helm repo (`CR_SKIP_EXISTING` — unchanged versions are skipped), leaving the packaged `.tgz` (deps vendored) in `.cr-release-packages/`.
-   - a later step in the same job `helm push`es those same packages to the `homeylabcharts` OCI registry on Docker Hub — so OCI publishes **only** the charts Pages just did, and a failed release blocks the push (the two channels can't desync).
+   - **`chart-releaser`** publishes any chart whose `Chart.yaml` `version` changed to the GitHub Pages Helm repo (`CR_SKIP_EXISTING` — unchanged versions are skipped), leaving the packaged `.tgz` (deps vendored) in `.cr-release-packages/`. It *packages* more than it publishes: the set is a file diff against `git describe --tags --abbrev=0 HEAD~`, which with per-chart tags can resolve to a tag from an older release.
+   - a later step `helm push`es those packages to the `homeylabcharts` OCI registry on Docker Hub, **skipping any version already published there**. Pages is immutable by construction; the skip makes OCI match. Without it an unrelated edit republishes an unchanged chart under its existing tag with a new digest — `helm package` is not reproducible across checkouts (file mtimes land in the tarball).
 
 **Consequence:** a templates-only change with an unchanged `version` ships **nothing** via chart-releaser. Always bump `version` when you want a release.
 
-**If the OCI push step fails after the release already published to Pages** (e.g. a Docker Hub auth/network blip), re-running the job won't republish it — `chart-releaser` now sees the version as already released and repackages nothing, leaving `.cr-release-packages/` empty. Recover manually for the affected chart: `task pkg-with-dep APP=<chart>` then `task oci-push FILE=<chart>-<version>.tgz`.
+**If the OCI push step fails after the release already published to Pages** (e.g. a Docker Hub auth/network blip), **re-run the failed workflow run**. Same commit → same packaged set → the guard skips what landed and pushes only what didn't. Don't wait for the next merge: once that merge's own tags move the diff base, a chart it doesn't touch is no longer packaged. Fallback if the run is gone: `task pkg-with-dep APP=<chart>` then `task oci-push FILE=<chart>-<version>.tgz`.
+
+**A published version cannot be corrected in place.** Pages has never allowed it, and OCI no longer does either. Fix a bad release by superseding it with a new patch version, or by deleting the tag from *both* channels (the GitHub Release and its asset, the `gh-pages` `index.yaml` entry, and the Docker Hub tag) and letting the next merge republish.
 
 ### Umbrella charts: release the subchart first
 


### PR DESCRIPTION
## Changes

- `release.yml`: before each `helm push`, probe the OCI registry for that chart version. Present → skip; a definite `not found` → push; anything else (auth, DNS, 5xx) → fail the job.
- Chart name and version are read from the parent `Chart.yaml` inside the package tarball, with the match anchored to column 1.
- `CONTRIBUTING.md`: corrects the release section — OCI does not publish only what Pages published, and a failed push is recovered by re-running the same workflow run, not by a manual repackage.

## Motivation

Every merge re-pushed all eight charts to Docker Hub, not just the ones released. Two runs four hours apart pushed the same set while one chart changed in each; bookstack 5.5.0, pihole 2.1.0, qbittorrent-exporter 1.2.0, tdarr-exporter 2.2.0 and unpoller 4.3.0 were republished under their existing tags both times.

`cr` packages every chart whose files changed since `git describe --tags --abbrev=0 HEAD~`, which assumes one linear release tag. With per-chart tags the base is whichever tag `describe` picks — locally it picked `bookstack-5.5.0` and reported all eight charts changed. `CR_SKIP_EXISTING` gates only the Pages upload, so Pages published two charts while OCI pushed eight.

That moves published digests: `helm package` is not reproducible across checkouts, since file mtimes land in the tarball. Nothing user-visible breaks today — content does not diverge between the channels, because `.helmignore` and `ct list-changed`'s `use-helmignore` cover the same paths, so any in-package change trips `check-version-increment`. That symmetry is undocumented and unenforced. The value is that digests stop moving before signing is added: cosign binds a signature to the digest, `.prov` to the tarball hash.

## Test plan

Probe branches, run against Docker Hub with helm v4.2.3:

| case | result | branch |
| --- | --- | --- |
| `pihole-exporter --version 2.1.0` | exit 0 | skip |
| `pihole-exporter --version 99.99.99` | `...: not found` | push |
| nonexistent repository in the namespace | `...: not found` | push |
| repository requiring auth | `response status code 401: unauthorized` | fail |
| unresolvable registry host | `dial tcp: ... no such host` | fail |

- Full loop over all nine packages in `.cr-release-packages/` with `helm push` stubbed: 9 skipped, 0 pushed, 0 failed.
- Metadata extraction checked against both umbrellas — `bookstack` 5.5.0 pulled from OCI and `exportarr` 4.4.0 packaged with `-u` — resolving to the parent, not a dependency.
- Non-reproducibility reproduced: the same chart packaged twice from one tree gives an identical sha256; packaged from a copy with fresh mtimes and identical contents, a different one.
- `actionlint` clean (bundled shellcheck covers the `run:` block).

## In-depth

**Why the match is anchored.** `helm package` sorts `Chart.yaml` keys, so `annotations:` and `dependencies:` both precede `name:`, and both carry their own indented `name:`/`version:` entries. An unanchored match resolves `bookstack` to `mariadb` and `exportarr` to `qbittorrent-exporter`. Reading the parent `Chart.yaml` out of the tarball is belt-and-braces: `helm show chart` on an umbrella package prints exactly the parent `Chart.yaml` (verified on helm 3.19 and 4.2.3), so it would serve equally well — the anchoring is the part that matters.

**Prior art.** `cloudnative-pg/charts` (`release-publish.yml`) uses the same three-state, fail-closed probe; `valkey-io/valkey-helm` uses a two-state variant that treats any error as absent. Neither carries the ordering bug — cnpg parses with `yq`, valkey already anchors its grep.

**Recovery is per-run, not per-merge.** Re-running the failed run recomputes the same diff base and repackages the same set, and the guard makes the retry idempotent. Waiting for the next merge does not work in general: that merge's own tags can move the base, and a chart it does not touch is then never repackaged.

**Not covered.** The probe checks that a tag exists, not that its content matches; correcting a published version in place remains impossible on both channels.
