### PR TITLE
ci: reuse the open link-rot issue instead of filing a new one weekly

### DIFF
--- a/.github/workflows/link-rot.yml
+++ b/.github/workflows/link-rot.yml
@@ -38,7 +38,11 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      issues: write # peter-evans/create-issue-from-file
+      issues: write # peter-evans/create-issue-from-file, and the close step below
+    env:
+      # One title, three consumers: the lookup matches on it, the action sets it,
+      # and the close step reports it. Changing it orphans whatever issue is open.
+      REPORT_TITLE: Broken links found in the docs
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -59,6 +63,11 @@ jobs:
       # github.com links, which rate-limit hard when unauthenticated. A non-zero
       # exit is recorded rather than failing the step: the issue is the
       # deliverable, and a red cron run notifies nobody.
+      #
+      # The footer is not decoration. The issue body is overwritten in place each
+      # week (see below), and an overwrite with byte-identical content is invisible
+      # — no diff, no notification, an issue that reads as abandoned. The timestamp
+      # and run link are what make "still broken as of Monday" legible.
       - name: Run lychee
         id: lychee
         env:
@@ -66,12 +75,65 @@ jobs:
         run: |
           set +e
           bash scripts/ci/check-links.sh --online lychee-report.md
-          echo "exit=$?" >> "$GITHUB_OUTPUT"
+          code=$?
+          set -e
+          echo "exit=$code" >> "$GITHUB_OUTPUT"
 
-      - name: Open an issue for the broken links
+          # Guard the footer append: if lychee died before writing anything, an
+          # unguarded >> would file an issue whose entire body is the footer.
+          if [ ! -f lychee-report.md ]; then
+            echo "lychee exited ${code} without writing a report. See the workflow run." > lychee-report.md
+          fi
+          printf '\n---\n_Last checked %s, commit \x60%s\x60 — [workflow run](%s/%s/actions/runs/%s)._\n' \
+            "$(date -u '+%Y-%m-%d %H:%M UTC')" "$GITHUB_SHA" \
+            "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID" >> lychee-report.md
+
+      # Without this the cron files a brand-new issue every Monday for the same
+      # dead link, and the pile trains people to close them unread — the exact
+      # failure the weekly-not-daily cadence was chosen to avoid.
+      #
+      # --state open is load-bearing. create-issue-from-file's `issue-number` path
+      # calls issues.update({title, body}) and never touches state (verified in
+      # src/main.ts at v6.0.0), so aiming it at a CLOSED issue would silently
+      # rewrite it with nobody notified. Matching only open issues means closing a
+      # report is a real decision: the next failing run files a fresh one.
+      #
+      # Restricted to bot-authored issues so a human opening an issue with the same
+      # title does not get their body overwritten by the next cron run.
+      - name: Find the open report issue
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          number=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --limit 100 \
+            --json number,title,author \
+            --jq '[.[] | select(.title == env.REPORT_TITLE and .author.is_bot)] | first | .number // empty')
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+          if [ -n "$number" ]; then
+            echo "Reusing issue #${number}"
+          else
+            echo "No open report issue; a new one will be filed if links are broken"
+          fi
+
+      # An empty issue-number means "create": the action does
+      # Number(core.getInput('issue-number')), and Number('') === 0 is falsy. So the
+      # lookup's output passes straight through, no conditional needed.
+      - name: Open or update the issue
         if: steps.lychee.outputs.exit != '0'
         uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
         with:
-          title: Broken links found in the docs
+          issue-number: ${{ steps.existing.outputs.number }}
+          title: ${{ env.REPORT_TITLE }}
           content-filepath: ./lychee-report.md
           labels: documentation
+
+      # The other half of dedupe. Without it a fixed link leaves the report open
+      # forever, and the next genuine break has nowhere to go but that stale issue.
+      - name: Close the report issue now the links are clean
+        if: steps.lychee.outputs.exit == '0' && steps.existing.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE: ${{ steps.existing.outputs.number }}
+        run: |
+          gh issue close "$ISSUE" --repo "$GITHUB_REPOSITORY" \
+            --comment "Every link resolves again as of commit \`${GITHUB_SHA}\` ([workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})). Closing automatically; the next failing run will file a new report."


### PR DESCRIPTION
Relates to #188 (the report issue this now reuses).

## Changes

- `.github/workflows/link-rot.yml` looks up the open, bot-authored report issue by title and passes it to `create-issue-from-file` as `issue-number`, so a still-broken link updates the existing report rather than opening another one.
- A run that finds every link resolving closes the open report with a comment.
- The report body gains a `Last checked <timestamp>, commit <sha> — workflow run` footer.
- The title lives in one job-level `env: REPORT_TITLE`, read by the lookup, the action, and the close step.

## Motivation

The cron called `create-issue-from-file` with no `issue-number`, so every Monday with a dead link opened another issue for the same dead link. A pile of identical reports is what trains people to close them unread — the failure the weekly-rather-than-daily cadence was already chosen to avoid.

The closing half matters as much: without it a fixed link leaves the report open forever, and the next genuine break lands on a stale issue instead of a fresh one.

The footer is not decoration. The body is now overwritten in place, and an overwrite with byte-identical content produces no diff and no notification — the issue reads as abandoned while the link is still broken. The timestamp is what makes "still broken as of Monday" legible.

## Verification

Both paths were exercised live via `workflow_dispatch` on a non-default ref before merge, since neither can run in a PR.

**Update path** — run `32340547272` on this branch, against the still-broken `stunlock.com` link:

```
Reusing issue #188
Updated issue #188
```

`Open or update the issue` succeeded, `Close the report issue` skipped, and the issue list still topped out at #188 — no duplicate filed. The footer rendered.

**Close path** — run `32340646016` on a throwaway ref carrying a fix for the dead link, so lychee exited 0:

```
skipped   Open or update the issue
success   Close the report issue now the links are clean
```

`#188` went to `CLOSED` with the automatic comment. The test comment was deleted, `#188` reopened, and the throwaway ref removed — the issue is back to its pre-test state.

`actionlint` clean locally under the same digest-pinned `rhysd/actionlint:1.7.12` image CI uses, which lints the `run:` blocks with its bundled shellcheck.

## In-depth

**Why the lookup is scoped to open issues.** `create-issue-from-file`'s `issue-number` path calls `issues.update({title, body})` and never touches `state` — verified in `src/main.ts` at the pinned `v6.0.0`, not inferred from the README, which does not document the behaviour. Aimed at a closed issue it would silently rewrite it with nobody notified. Matching only open issues makes closing a report a real decision: the next failing run files a fresh one.

**Why no conditional around the action.** The same source does `Number(core.getInput('issue-number'))`, and `Number('') === 0` is falsy, so an empty lookup result passes straight through as "create".

**Why bot-authored only.** A human opening an issue under the same title would otherwise have their body overwritten by the next cron run.

**Why `gh` in a `run:` block rather than an action.** `micalevisk/last-issue-action` covers this, but it is another third-party action to SHA-pin and track; `gh` is preinstalled on the runner. Consistent with how this repo installs its other tooling.

**No upstream pattern was diverged from.** `lycheeverse/lychee-action`'s own README recipe files an issue with no dedupe at all.

**Not addressed.** The report still has no history — each overwrite discards the previous week's snapshot. The workflow run logs retain it for the retention window. Adding history would mean commenting rather than updating, which reintroduces the pile this removes.